### PR TITLE
Add a missing port to the custom_tb of digit_recognition example.

### DIFF
--- a/Training2/digit_recognition/custom_tb.v
+++ b/Training2/digit_recognition/custom_tb.v
@@ -97,6 +97,7 @@ ClassifierPipeline_top DUT (
   .clk (clk),
   .reset (reset),
   .start (~reset),
+  .ready (),
   .finish (),
 
   .classifier_input_valid_write_en (classifier_input_valid_write_en),


### PR DESCRIPTION
When simulating with VHDL wrapper, missing port connections will cause warnings.