### PR TITLE
Add missing port in custom testbench for digit recognition

### DIFF
--- a/Training2/digit_recognition/custom_tb.v
+++ b/Training2/digit_recognition/custom_tb.v
@@ -104,6 +104,7 @@ ClassifierPipeline_top DUT (
   .classifier_input_valid_write_data (classifier_input_valid_write_data),
   .classifier_input_valid_read_data (classifier_input_valid_read_data),
 
+  .classifier_input_clken (),
   .classifier_input_address_a (classifier_input_a0_a0_a0_address_a),
   .classifier_input_read_data_a (classifier_input_a0_a0_a0_read_data_a),
   .classifier_input_read_data_b (16'bX /* should be unused */),


### PR DESCRIPTION
The missing port generates a warning in Modelsim whenever we use the VHDL
wrappers, which causes a test to fail.