### PR TITLE
Update all Libero core versions to use "*" for the latest versions

### DIFF
--- a/Libero/README.txt
+++ b/Libero/README.txt
@@ -14,8 +14,3 @@ Each of the Libero subdirectories contains the following:
 4. libero_flow.tcl - this is the file that needs to be sourced to the Libero
    executable in script mode. You can also run this file in the IDE by
    selecting <Project><Execute Script>
-
-Note: While running libero_flow.tcl, if you see a failure in configuring a
-particular core because it is no longer supported in that particular Libero
-release, you can edit the top of libero_flow.tcl to update the version of 
-that particular core with the latest version.

--- a/Training1/Libero/libero_flow.tcl
+++ b/Training1/Libero/libero_flow.tcl
@@ -2,56 +2,31 @@
 
 new_project -location {./Libero_training1} -name {Libero_training1} -project_description {} -block_mode 0 -hdl Verilog -family {PolarFire} -die {MPF300TS} -package {FCG1152} -speed {-1} -die_voltage {1.0} -part_range {IND} -adv_options {IO_DEFT_STD:LVCMOS 1.8V} -adv_options {RESERVEMIGRATIONPINS:1} -adv_options {RESTRICTPROBEPINS:1} -adv_options {RESTRICTSPIPINS:0} -adv_options {TEMPR:IND} -adv_options {UNUSED_MSS_IO_RESISTOR_PULL:None} -adv_options {VCCI_1.2_VOLTR:IND} -adv_options {VCCI_1.5_VOLTR:IND} -adv_options {VCCI_1.8_VOLTR:IND} -adv_options {VCCI_2.5_VOLTR:IND} -adv_options {VCCI_3.3_VOLTR:IND} -adv_options {VOLTR:IND} 
 
-set PF_CCC_version 2.2.214
-set Display_Controller_version 3.1.2
-set HDMI_RX_version  4.2.0
-set HDMI_TX_version  1.0.2
-set PF_TX_PLL_version  2.0.300
-set PF_XCVR_ERM_version  3.1.200
-set PF_XCVR_REF_CLK_version  1.0.103
-set CORERESET_PF_version  2.2.107
-set CORERXIODBITALIGN_version  2.1.104
-set PF_IOD_GENERIC_RX_version  2.1.109
-set PF_DDR4_version  2.5.108
-set PF_SRAM_AHBL_AXI_version  1.2.108
-set mipicsi2rxdecoderPF_version  2.2.5
-set COREAHBTOAPB3_version  3.1.100
-set COREI2C_version  7.2.101
-set CoreAPB3_version  4.1.100
-set CoreGPIO_version  3.2.102
-set COREJTAGDEBUG_version  3.1.100
-set CoreAHBLite_version  5.4.102
-set PF_INIT_MONITOR_version  2.0.304
-set MIV_RV32IMA_L1_AHB_version  2.3.100
-set COREUART_version 5.6.102
-set Bayer_Interpolation_version 3.0.2
-set Image_Enhancement_version 3.0.0
-
 #Download all the required cores to the vault
-download_core -vlnv "Actel:SgCore:PF_CCC:${PF_CCC_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Microsemi:SolutionCore:Display_Controller:${Display_Controller_version}"  -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Microsemi:SolutionCore:HDMI_RX:${HDMI_RX_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Microsemi:SolutionCore:HDMI_TX:${HDMI_TX_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:SgCore:PF_TX_PLL:${PF_TX_PLL_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Actel:SystemBuilder:PF_XCVR_ERM:${PF_XCVR_ERM_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Actel:SgCore:PF_XCVR_REF_CLK:${PF_XCVR_REF_CLK_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Actel:DirectCore:CORERESET_PF:${CORERESET_PF_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:CORERXIODBITALIGN:${CORERXIODBITALIGN_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:SystemBuilder:PF_IOD_GENERIC_RX:${PF_IOD_GENERIC_RX_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Actel:SystemBuilder:PF_DDR4:${PF_DDR4_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Actel:SystemBuilder:PF_SRAM_AHBL_AXI:${PF_SRAM_AHBL_AXI_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Microsemi:SolutionCore:mipicsi2rxdecoderPF:${mipicsi2rxdecoderPF_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:COREAHBTOAPB3:${COREAHBTOAPB3_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:COREI2C:${COREI2C_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:CoreAPB3:${CoreAPB3_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:CoreGPIO:${CoreGPIO_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:COREJTAGDEBUG:${COREJTAGDEBUG_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:CoreAHBLite:${CoreAHBLite_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:SgCore:PF_INIT_MONITOR:${PF_INIT_MONITOR_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Microsemi:MiV:MIV_RV32IMA_L1_AHB:${MIV_RV32IMA_L1_AHB_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:COREUART:${COREUART_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Microsemi:SolutionCore:Bayer_Interpolation:${Bayer_Interpolation_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Microsemi:SolutionCore:Image_Enhancement:${Image_Enhancement_version}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:SgCore:PF_CCC:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Microsemi:SolutionCore:Display_Controller:*}"  -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Microsemi:SolutionCore:HDMI_RX:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Microsemi:SolutionCore:HDMI_TX:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:SgCore:PF_TX_PLL:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Actel:SystemBuilder:PF_XCVR_ERM:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Actel:SgCore:PF_XCVR_REF_CLK:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Actel:DirectCore:CORERESET_PF:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:CORERXIODBITALIGN:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:SystemBuilder:PF_IOD_GENERIC_RX:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Actel:SystemBuilder:PF_DDR4:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Actel:SystemBuilder:PF_SRAM_AHBL_AXI:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Microsemi:SolutionCore:mipicsi2rxdecoderPF:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:COREAHBTOAPB3:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:COREI2C:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:CoreAPB3:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:CoreGPIO:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:COREJTAGDEBUG:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:CoreAHBLite:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:SgCore:PF_INIT_MONITOR:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Microsemi:MiV:MIV_RV32IMA_L1_AHB:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:COREUART:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Microsemi:SolutionCore:Bayer_Interpolation:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Microsemi:SolutionCore:Image_Enhancement:*}" -location {www.microchip-ip.com/repositories/DirectCore}
 
 #source the below tcl file to create the top level SmartDesign and generate it
 source ./src/VIDEO_KIT_TOP_recursive.tcl

--- a/Training1/Libero/src/components/Bayer_Interpolation_C0.tcl
+++ b/Training1/Libero/src/components/Bayer_Interpolation_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component Bayer_Interpolation_C0
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:Bayer_Interpolation:$Bayer_Interpolation_version -component_name {Bayer_Interpolation_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:Bayer_Interpolation:* -component_name {Bayer_Interpolation_C0} -params {\
 "G_DATA_WIDTH:8"  \
 "G_PIXELS:1"  \
 "G_RAM_SIZE:2048"   }

--- a/Training1/Libero/src/components/Bayer_Interpolation_C1.tcl
+++ b/Training1/Libero/src/components/Bayer_Interpolation_C1.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component Bayer_Interpolation_C1
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:Bayer_Interpolation:$Bayer_Interpolation_version -component_name {Bayer_Interpolation_C1} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:Bayer_Interpolation:* -component_name {Bayer_Interpolation_C1} -params {\
 "G_DATA_WIDTH:8"  \
 "G_PIXELS:1"  \
 "G_RAM_SIZE:2048"   }

--- a/Training1/Libero/src/components/Bayer_Interpolation_C2.tcl
+++ b/Training1/Libero/src/components/Bayer_Interpolation_C2.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component Bayer_Interpolation_C2
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:Bayer_Interpolation:$Bayer_Interpolation_version -component_name {Bayer_Interpolation_C2} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:Bayer_Interpolation:* -component_name {Bayer_Interpolation_C2} -params {\
 "G_DATA_WIDTH:8"  \
 "G_PIXELS:4"  \
 "G_RAM_SIZE:2048"   }

--- a/Training1/Libero/src/components/COREI2C_C0.tcl
+++ b/Training1/Libero/src/components/COREI2C_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component COREI2C_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:COREI2C:$COREI2C_version -component_name {COREI2C_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:COREI2C:* -component_name {COREI2C_C0} -params {\
 "ADD_SLAVE1_ADDRESS_EN:false"  \
 "BAUD_RATE_FIXED:false"  \
 "BAUD_RATE_VALUE:0"  \

--- a/Training1/Libero/src/components/CORERESET_PF_C0.tcl
+++ b/Training1/Libero/src/components/CORERESET_PF_C0.tcl
@@ -2,5 +2,5 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERESET_PF_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:$CORERESET_PF_version -component_name {CORERESET_PF_C0} -params { }
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:* -component_name {CORERESET_PF_C0} -params { }
 # Exporting Component Description of CORERESET_PF_C0 to TCL done

--- a/Training1/Libero/src/components/CORERESET_PF_C1.tcl
+++ b/Training1/Libero/src/components/CORERESET_PF_C1.tcl
@@ -2,5 +2,5 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERESET_PF_C1
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:$CORERESET_PF_version -component_name {CORERESET_PF_C1} -params { }
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:* -component_name {CORERESET_PF_C1} -params { }
 # Exporting Component Description of CORERESET_PF_C1 to TCL done

--- a/Training1/Libero/src/components/CORERESET_PF_C2.tcl
+++ b/Training1/Libero/src/components/CORERESET_PF_C2.tcl
@@ -2,5 +2,5 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERESET_PF_C2
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:$CORERESET_PF_version -component_name {CORERESET_PF_C2} -params { }
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:* -component_name {CORERESET_PF_C2} -params { }
 # Exporting Component Description of CORERESET_PF_C2 to TCL done

--- a/Training1/Libero/src/components/CORERESET_PF_C3.tcl
+++ b/Training1/Libero/src/components/CORERESET_PF_C3.tcl
@@ -2,5 +2,5 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERESET_PF_C3
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:$CORERESET_PF_version -component_name {CORERESET_PF_C3} -params { }
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:* -component_name {CORERESET_PF_C3} -params { }
 # Exporting Component Description of CORERESET_PF_C3 to TCL done

--- a/Training1/Libero/src/components/CORERXIODBITALIGN_C0.tcl
+++ b/Training1/Libero/src/components/CORERXIODBITALIGN_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERXIODBITALIGN_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:$CORERXIODBITALIGN_version -component_name {CORERXIODBITALIGN_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:* -component_name {CORERXIODBITALIGN_C0} -params {\
 "HOLD_TRNG:0"  \
 "MIPI_TRNG:1"  \
 "SKIP_TRNG:0"   }

--- a/Training1/Libero/src/components/CORERXIODBITALIGN_C1.tcl
+++ b/Training1/Libero/src/components/CORERXIODBITALIGN_C1.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERXIODBITALIGN_C1
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:$CORERXIODBITALIGN_version -component_name {CORERXIODBITALIGN_C1} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:* -component_name {CORERXIODBITALIGN_C1} -params {\
 "DEM_TAP_WAIT_CNT_WIDTH:3"  \
 "HOLD_TRNG:0"  \
 "MIPI_TRNG:1"  \

--- a/Training1/Libero/src/components/CORERXIODBITALIGN_C2.tcl
+++ b/Training1/Libero/src/components/CORERXIODBITALIGN_C2.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERXIODBITALIGN_C2
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:$CORERXIODBITALIGN_version -component_name {CORERXIODBITALIGN_C2} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:* -component_name {CORERXIODBITALIGN_C2} -params {\
 "HOLD_TRNG:0"  \
 "MIPI_TRNG:1"  \
 "SKIP_TRNG:0"   }

--- a/Training1/Libero/src/components/CORERXIODBITALIGN_C3.tcl
+++ b/Training1/Libero/src/components/CORERXIODBITALIGN_C3.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERXIODBITALIGN_C3
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:$CORERXIODBITALIGN_version -component_name {CORERXIODBITALIGN_C3} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:* -component_name {CORERXIODBITALIGN_C3} -params {\
 "HOLD_TRNG:0"  \
 "MIPI_TRNG:1"  \
 "SKIP_TRNG:0"   }

--- a/Training1/Libero/src/components/COREUART_C0.tcl
+++ b/Training1/Libero/src/components/COREUART_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component COREUART_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:COREUART:$COREUART_version -component_name {COREUART_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:COREUART:* -component_name {COREUART_C0} -params {\
 "BAUD_VAL_FRCTN_EN:true"  \
 "RX_FIFO:0"  \
 "RX_LEGACY_MODE:0"  \

--- a/Training1/Libero/src/components/CoreAHBLite_C0.tcl
+++ b/Training1/Libero/src/components/CoreAHBLite_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CoreAHBLite_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:CoreAHBLite:$CoreAHBLite_version -component_name {CoreAHBLite_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CoreAHBLite:* -component_name {CoreAHBLite_C0} -params {\
 "HADDR_SHG_CFG:1"  \
 "M0_AHBSLOT0ENABLE:false"  \
 "M0_AHBSLOT1ENABLE:false"  \

--- a/Training1/Libero/src/components/Display_Controller_C0.tcl
+++ b/Training1/Libero/src/components/Display_Controller_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component Display_Controller_C0
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:Display_Controller:$Display_Controller_version -component_name {Display_Controller_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:Display_Controller:* -component_name {Display_Controller_C0} -params {\
 "g_PIXELS_PER_CLK:1"  \
 "g_VIDEO_FORMAT:1"   }
 # Exporting Component Description of Display_Controller_C0 to TCL done

--- a/Training1/Libero/src/components/Display_Controller_C1.tcl
+++ b/Training1/Libero/src/components/Display_Controller_C1.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component Display_Controller_C1
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:Display_Controller:$Display_Controller_version -component_name {Display_Controller_C1} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:Display_Controller:* -component_name {Display_Controller_C1} -params {\
 "g_PIXELS_PER_CLK:4"  \
 "g_VIDEO_FORMAT:2"   }
 # Exporting Component Description of Display_Controller_C1 to TCL done

--- a/Training1/Libero/src/components/HDMI_RX_C0.tcl
+++ b/Training1/Libero/src/components/HDMI_RX_C0.tcl
@@ -2,6 +2,6 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component HDMI_RX_C0
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:HDMI_RX:$HDMI_RX_version -component_name {HDMI_RX_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:HDMI_RX:* -component_name {HDMI_RX_C0} -params {\
 "G_FORMAT:0"   }
 # Exporting Component Description of HDMI_RX_C0 to TCL done

--- a/Training1/Libero/src/components/HDMI_TX_C0.tcl
+++ b/Training1/Libero/src/components/HDMI_TX_C0.tcl
@@ -2,6 +2,6 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component HDMI_TX_C0
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:HDMI_TX:$HDMI_TX_version -component_name {HDMI_TX_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:HDMI_TX:* -component_name {HDMI_TX_C0} -params {\
 "g_PIXELS_PER_CLK:4"   }
 # Exporting Component Description of HDMI_TX_C0 to TCL done

--- a/Training1/Libero/src/components/Image_Enhancement_C0.tcl
+++ b/Training1/Libero/src/components/Image_Enhancement_C0.tcl
@@ -2,6 +2,6 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component Image_Enhancement_C0
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:Image_Enhancement:$Image_Enhancement_version -component_name {Image_Enhancement_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:Image_Enhancement:* -component_name {Image_Enhancement_C0} -params {\
 "G_PIXEL_WIDTH:8"   }
 # Exporting Component Description of Image_Enhancement_C0 to TCL done

--- a/Training1/Libero/src/components/Image_Enhancement_C1.tcl
+++ b/Training1/Libero/src/components/Image_Enhancement_C1.tcl
@@ -2,6 +2,6 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component Image_Enhancement_C1
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:Image_Enhancement:$Image_Enhancement_version -component_name {Image_Enhancement_C1} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:Image_Enhancement:* -component_name {Image_Enhancement_C1} -params {\
 "G_PIXEL_WIDTH:8"   }
 # Exporting Component Description of Image_Enhancement_C1 to TCL done

--- a/Training1/Libero/src/components/MIV_RV32IMA_L1_AHB_C0.tcl
+++ b/Training1/Libero/src/components/MIV_RV32IMA_L1_AHB_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component MIV_RV32IMA_L1_AHB_C0
-create_and_configure_core -core_vlnv Microsemi:MiV:MIV_RV32IMA_L1_AHB:$MIV_RV32IMA_L1_AHB_version -component_name {MIV_RV32IMA_L1_AHB_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:MiV:MIV_RV32IMA_L1_AHB:* -component_name {MIV_RV32IMA_L1_AHB_C0} -params {\
 "ECC_EN:false"  \
 "EXT_HALT:false"  \
 "RESET_VECTOR_ADDR_0:0x0"  \

--- a/Training1/Libero/src/components/PF_CCC_C0.tcl
+++ b/Training1/Libero/src/components/PF_CCC_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_CCC_C0
-create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:$PF_CCC_version -component_name {PF_CCC_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:* -component_name {PF_CCC_C0} -params {\
 "DLL_CLK_0_BANKCLK_EN:false"  \
 "DLL_CLK_0_DEDICATED_EN:false"  \
 "DLL_CLK_0_FABCLK_EN:false"  \

--- a/Training1/Libero/src/components/PF_CCC_C1.tcl
+++ b/Training1/Libero/src/components/PF_CCC_C1.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_CCC_C1
-create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:$PF_CCC_version -component_name {PF_CCC_C1} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:* -component_name {PF_CCC_C1} -params {\
 "DLL_CLK_0_BANKCLK_EN:false"  \
 "DLL_CLK_0_DEDICATED_EN:false"  \
 "DLL_CLK_0_FABCLK_EN:false"  \

--- a/Training1/Libero/src/components/PF_CCC_C2.tcl
+++ b/Training1/Libero/src/components/PF_CCC_C2.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_CCC_C2
-create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:$PF_CCC_version -component_name {PF_CCC_C2} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:* -component_name {PF_CCC_C2} -params {\
 "DLL_CLK_0_BANKCLK_EN:false"  \
 "DLL_CLK_0_DEDICATED_EN:false"  \
 "DLL_CLK_0_FABCLK_EN:false"  \

--- a/Training1/Libero/src/components/PF_DDR4_C0.tcl
+++ b/Training1/Libero/src/components/PF_DDR4_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_DDR4_C0
-create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_DDR4:$PF_DDR4_version -component_name {PF_DDR4_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_DDR4:* -component_name {PF_DDR4_C0} -params {\
 "ADDRESS_MIRROR:false" \
 "ADDRESS_ORDERING:CHIP_ROW_BG_BANK_COL" \
 "AUTO_SELF_REFRESH:3" \

--- a/Training1/Libero/src/components/PF_INIT_MONITOR_C0.tcl
+++ b/Training1/Libero/src/components/PF_INIT_MONITOR_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_INIT_MONITOR_C0
-create_and_configure_core -core_vlnv Actel:SgCore:PF_INIT_MONITOR:$PF_INIT_MONITOR_version -component_name {PF_INIT_MONITOR_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_INIT_MONITOR:* -component_name {PF_INIT_MONITOR_C0} -params {\
 "BANK_0_CALIB_STATUS_ENABLED:false"  \
 "BANK_0_CALIB_STATUS_SIMULATION_DELAY:1"  \
 "BANK_0_RECALIBRATION_ENABLED:false"  \

--- a/Training1/Libero/src/components/PF_IOD_GENERIC_RX_C0.tcl
+++ b/Training1/Libero/src/components/PF_IOD_GENERIC_RX_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_IOD_GENERIC_RX_C0
-create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_IOD_GENERIC_RX:$PF_IOD_GENERIC_RX_version -component_name {PF_IOD_GENERIC_RX_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_IOD_GENERIC_RX:* -component_name {PF_IOD_GENERIC_RX_C0} -params {\
 "CLOCK_DELAY_VALUE:0" \
 "DATA_RATE:1200" \
 "DATA_RATIO:8" \

--- a/Training1/Libero/src/components/PF_SRAM_AHBL_AXI_C0.tcl
+++ b/Training1/Libero/src/components/PF_SRAM_AHBL_AXI_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_SRAM_AHBL_AXI_C0
-create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_SRAM_AHBL_AXI:$PF_SRAM_AHBL_AXI_version -component_name {PF_SRAM_AHBL_AXI_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_SRAM_AHBL_AXI:* -component_name {PF_SRAM_AHBL_AXI_C0} -params {\
 "AXI4_AWIDTH:32" \
 "AXI4_DWIDTH:32" \
 "AXI4_IDWIDTH:8" \

--- a/Training1/Libero/src/components/PF_TX_PLL_C0.tcl
+++ b/Training1/Libero/src/components/PF_TX_PLL_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_TX_PLL_C0
-create_and_configure_core -core_vlnv Actel:SgCore:PF_TX_PLL:$PF_TX_PLL_version -component_name {PF_TX_PLL_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_TX_PLL:* -component_name {PF_TX_PLL_C0} -params {\
 "CORE:PF_TX_PLL"  \
 "INIT:0x0"  \
 "TxPLL_AUX_LOW_SEL:true"  \

--- a/Training1/Libero/src/components/PF_XCVR_ERM_C0.tcl
+++ b/Training1/Libero/src/components/PF_XCVR_ERM_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_XCVR_ERM_C0
-create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_XCVR_ERM:$PF_XCVR_ERM_version -component_name {PF_XCVR_ERM_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_XCVR_ERM:* -component_name {PF_XCVR_ERM_C0} -params {\
 "EXPOSE_ALL_DEBUG_PORTS:false" \
 "EXPOSE_FWF_EN_PORTS:false" \
 "SHOW_UNIVERSAL_SOLN_PORTS:true" \

--- a/Training1/Libero/src/components/PF_XCVR_REF_CLK_C0.tcl
+++ b/Training1/Libero/src/components/PF_XCVR_REF_CLK_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_XCVR_REF_CLK_C0
-create_and_configure_core -core_vlnv Actel:SgCore:PF_XCVR_REF_CLK:$PF_XCVR_REF_CLK_version -component_name {PF_XCVR_REF_CLK_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_XCVR_REF_CLK:* -component_name {PF_XCVR_REF_CLK_C0} -params {\
 "ENABLE_FAB_CLK_0:false"  \
 "ENABLE_FAB_CLK_1:false"  \
 "ENABLE_REF_CLK_0:true"  \

--- a/Training1/Libero/src/components/mipicsi2rxdecoderPF_C0.tcl
+++ b/Training1/Libero/src/components/mipicsi2rxdecoderPF_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component mipicsi2rxdecoderPF_C0
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:mipicsi2rxdecoderPF:$mipicsi2rxdecoderPF_version -component_name {mipicsi2rxdecoderPF_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:mipicsi2rxdecoderPF:* -component_name {mipicsi2rxdecoderPF_C0} -params {\
 "g_BUFF_DEPTH:1920"  \
 "g_DATAWIDTH:10"  \
 "g_INPUT_DATA_INVERT:0"  \

--- a/Training2/Libero/libero_flow.tcl
+++ b/Training2/Libero/libero_flow.tcl
@@ -2,46 +2,26 @@
 
 new_project -location {./Libero_training2} -name {Libero_training2} -project_description {} -block_mode 0 -hdl Verilog -family {PolarFire} -die {MPF300TS} -package {FCG1152} -speed {-1} -die_voltage {1.0} -part_range {IND} -adv_options {IO_DEFT_STD:LVCMOS 1.8V} -adv_options {RESERVEMIGRATIONPINS:1} -adv_options {RESTRICTPROBEPINS:1} -adv_options {RESTRICTSPIPINS:0} -adv_options {TEMPR:IND} -adv_options {UNUSED_MSS_IO_RESISTOR_PULL:None} -adv_options {VCCI_1.2_VOLTR:IND} -adv_options {VCCI_1.5_VOLTR:IND} -adv_options {VCCI_1.8_VOLTR:IND} -adv_options {VCCI_2.5_VOLTR:IND} -adv_options {VCCI_3.3_VOLTR:IND} -adv_options {VOLTR:IND} 
 
-set PF_CCC_version 2.2.214
-set Display_Controller_version 3.1.2
-set CORERESET_PF_version  2.2.107
-set CORERXIODBITALIGN_version  2.1.104
-set PF_IOD_GENERIC_RX_version  2.1.109
-set PF_DDR4_version  2.5.108
-set PF_SRAM_AHBL_AXI_version  1.2.108
-set mipicsi2rxdecoderPF_version  2.2.5
-set COREAHBTOAPB3_version  3.1.100
-set COREI2C_version  7.2.101
-set CoreAPB3_version  4.1.100
-set CoreGPIO_version  3.2.102
-set COREJTAGDEBUG_version  3.1.100
-set CoreAHBLite_version  5.4.102
-set PF_INIT_MONITOR_version  2.0.304
-set MIV_RV32IMA_L1_AHB_version  2.3.100
-set COREUART_version 5.6.102
-set Bayer_Interpolation_version 3.0.2
-set Image_Enhancement_version 3.0.0
-
 #Download all the required cores to the vault
-download_core -vlnv "Actel:SgCore:PF_CCC:${PF_CCC_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Microsemi:SolutionCore:Display_Controller:${Display_Controller_version}"  -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:CORERESET_PF:${CORERESET_PF_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:CORERXIODBITALIGN:${CORERXIODBITALIGN_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:SystemBuilder:PF_IOD_GENERIC_RX:${PF_IOD_GENERIC_RX_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Actel:SystemBuilder:PF_DDR4:${PF_DDR4_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Actel:SystemBuilder:PF_SRAM_AHBL_AXI:${PF_SRAM_AHBL_AXI_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Microsemi:SolutionCore:mipicsi2rxdecoderPF:${mipicsi2rxdecoderPF_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:COREAHBTOAPB3:${COREAHBTOAPB3_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:COREI2C:${COREI2C_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:CoreAPB3:${CoreAPB3_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:CoreGPIO:${CoreGPIO_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:COREJTAGDEBUG:${COREJTAGDEBUG_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:CoreAHBLite:${CoreAHBLite_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:SgCore:PF_INIT_MONITOR:${PF_INIT_MONITOR_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Microsemi:MiV:MIV_RV32IMA_L1_AHB:${MIV_RV32IMA_L1_AHB_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:COREUART:${COREUART_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Microsemi:SolutionCore:Bayer_Interpolation:${Bayer_Interpolation_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Microsemi:SolutionCore:Image_Enhancement:${Image_Enhancement_version}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:SgCore:PF_CCC:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Microsemi:SolutionCore:Display_Controller:*}"  -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:CORERESET_PF:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:CORERXIODBITALIGN:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:SystemBuilder:PF_IOD_GENERIC_RX:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Actel:SystemBuilder:PF_DDR4:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Actel:SystemBuilder:PF_SRAM_AHBL_AXI:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Microsemi:SolutionCore:mipicsi2rxdecoderPF:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:COREAHBTOAPB3:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:COREI2C:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:CoreAPB3:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:CoreGPIO:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:COREJTAGDEBUG:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:CoreAHBLite:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:SgCore:PF_INIT_MONITOR:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Microsemi:MiV:MIV_RV32IMA_L1_AHB:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:COREUART:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Microsemi:SolutionCore:Bayer_Interpolation:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Microsemi:SolutionCore:Image_Enhancement:*}" -location {www.microchip-ip.com/repositories/DirectCore}
 
 #source the below tcl file to create the top level SmartDesign and generate it
 source ./src/VIDEO_KIT_TOP_recursive.tcl

--- a/Training2/Libero/src/components/Bayer_Interpolation_C0.tcl
+++ b/Training2/Libero/src/components/Bayer_Interpolation_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component Bayer_Interpolation_C0
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:Bayer_Interpolation:$Bayer_Interpolation_version -component_name {Bayer_Interpolation_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:Bayer_Interpolation:* -component_name {Bayer_Interpolation_C0} -params {\
 "G_DATA_WIDTH:8"  \
 "G_PIXELS:1"  \
 "G_RAM_SIZE:2048"   }

--- a/Training2/Libero/src/components/Bayer_Interpolation_C1.tcl
+++ b/Training2/Libero/src/components/Bayer_Interpolation_C1.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component Bayer_Interpolation_C1
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:Bayer_Interpolation:$Bayer_Interpolation_version -component_name {Bayer_Interpolation_C1} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:Bayer_Interpolation:* -component_name {Bayer_Interpolation_C1} -params {\
 "G_DATA_WIDTH:8"  \
 "G_PIXELS:1"  \
 "G_RAM_SIZE:2048"   }

--- a/Training2/Libero/src/components/COREI2C_C0.tcl
+++ b/Training2/Libero/src/components/COREI2C_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component COREI2C_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:COREI2C:$COREI2C_version -component_name {COREI2C_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:COREI2C:* -component_name {COREI2C_C0} -params {\
 "ADD_SLAVE1_ADDRESS_EN:false"  \
 "BAUD_RATE_FIXED:false"  \
 "BAUD_RATE_VALUE:0"  \

--- a/Training2/Libero/src/components/CORERESET_PF_C1.tcl
+++ b/Training2/Libero/src/components/CORERESET_PF_C1.tcl
@@ -2,5 +2,5 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERESET_PF_C1
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:$CORERESET_PF_version -component_name {CORERESET_PF_C1} -params { }
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:* -component_name {CORERESET_PF_C1} -params { }
 # Exporting Component Description of CORERESET_PF_C1 to TCL done

--- a/Training2/Libero/src/components/CORERESET_PF_C2.tcl
+++ b/Training2/Libero/src/components/CORERESET_PF_C2.tcl
@@ -2,5 +2,5 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERESET_PF_C2
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:$CORERESET_PF_version -component_name {CORERESET_PF_C2} -params { }
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:* -component_name {CORERESET_PF_C2} -params { }
 # Exporting Component Description of CORERESET_PF_C2 to TCL done

--- a/Training2/Libero/src/components/CORERESET_PF_C3.tcl
+++ b/Training2/Libero/src/components/CORERESET_PF_C3.tcl
@@ -2,5 +2,5 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERESET_PF_C3
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:$CORERESET_PF_version -component_name {CORERESET_PF_C3} -params { }
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:* -component_name {CORERESET_PF_C3} -params { }
 # Exporting Component Description of CORERESET_PF_C3 to TCL done

--- a/Training2/Libero/src/components/CORERXIODBITALIGN_C0.tcl
+++ b/Training2/Libero/src/components/CORERXIODBITALIGN_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERXIODBITALIGN_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:$CORERXIODBITALIGN_version -component_name {CORERXIODBITALIGN_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:* -component_name {CORERXIODBITALIGN_C0} -params {\
 "HOLD_TRNG:0"  \
 "MIPI_TRNG:1"  \
 "SKIP_TRNG:0"   }

--- a/Training2/Libero/src/components/CORERXIODBITALIGN_C1.tcl
+++ b/Training2/Libero/src/components/CORERXIODBITALIGN_C1.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERXIODBITALIGN_C1
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:$CORERXIODBITALIGN_version -component_name {CORERXIODBITALIGN_C1} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:* -component_name {CORERXIODBITALIGN_C1} -params {\
 "DEM_TAP_WAIT_CNT_WIDTH:3"  \
 "HOLD_TRNG:0"  \
 "MIPI_TRNG:1"  \

--- a/Training2/Libero/src/components/CORERXIODBITALIGN_C2.tcl
+++ b/Training2/Libero/src/components/CORERXIODBITALIGN_C2.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERXIODBITALIGN_C2
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:$CORERXIODBITALIGN_version -component_name {CORERXIODBITALIGN_C2} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:* -component_name {CORERXIODBITALIGN_C2} -params {\
 "HOLD_TRNG:0"  \
 "MIPI_TRNG:1"  \
 "SKIP_TRNG:0"   }

--- a/Training2/Libero/src/components/CORERXIODBITALIGN_C3.tcl
+++ b/Training2/Libero/src/components/CORERXIODBITALIGN_C3.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CORERXIODBITALIGN_C3
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:$CORERXIODBITALIGN_version -component_name {CORERXIODBITALIGN_C3} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERXIODBITALIGN:* -component_name {CORERXIODBITALIGN_C3} -params {\
 "HOLD_TRNG:0"  \
 "MIPI_TRNG:1"  \
 "SKIP_TRNG:0"   }

--- a/Training2/Libero/src/components/COREUART_C0.tcl
+++ b/Training2/Libero/src/components/COREUART_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component COREUART_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:COREUART:$COREUART_version -component_name {COREUART_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:COREUART:* -component_name {COREUART_C0} -params {\
 "BAUD_VAL_FRCTN_EN:true"  \
 "RX_FIFO:0"  \
 "RX_LEGACY_MODE:0"  \

--- a/Training2/Libero/src/components/CoreAHBLite_C0.tcl
+++ b/Training2/Libero/src/components/CoreAHBLite_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component CoreAHBLite_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:CoreAHBLite:$CoreAHBLite_version -component_name {CoreAHBLite_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CoreAHBLite:* -component_name {CoreAHBLite_C0} -params {\
 "HADDR_SHG_CFG:1"  \
 "M0_AHBSLOT0ENABLE:false"  \
 "M0_AHBSLOT1ENABLE:false"  \

--- a/Training2/Libero/src/components/Display_Controller_C0.tcl
+++ b/Training2/Libero/src/components/Display_Controller_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component Display_Controller_C0
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:Display_Controller:$Display_Controller_version -component_name {Display_Controller_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:Display_Controller:* -component_name {Display_Controller_C0} -params {\
 "g_PIXELS_PER_CLK:1"  \
 "g_VIDEO_FORMAT:1"   }
 # Exporting Component Description of Display_Controller_C0 to TCL done

--- a/Training2/Libero/src/components/Image_Enhancement_C0.tcl
+++ b/Training2/Libero/src/components/Image_Enhancement_C0.tcl
@@ -2,6 +2,6 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component Image_Enhancement_C0
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:Image_Enhancement:$Image_Enhancement_version -component_name {Image_Enhancement_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:Image_Enhancement:* -component_name {Image_Enhancement_C0} -params {\
 "G_PIXEL_WIDTH:8"   }
 # Exporting Component Description of Image_Enhancement_C0 to TCL done

--- a/Training2/Libero/src/components/MIV_RV32IMA_L1_AHB_C0.tcl
+++ b/Training2/Libero/src/components/MIV_RV32IMA_L1_AHB_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component MIV_RV32IMA_L1_AHB_C0
-create_and_configure_core -core_vlnv Microsemi:MiV:MIV_RV32IMA_L1_AHB:$MIV_RV32IMA_L1_AHB_version -component_name {MIV_RV32IMA_L1_AHB_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:MiV:MIV_RV32IMA_L1_AHB:* -component_name {MIV_RV32IMA_L1_AHB_C0} -params {\
 "ECC_EN:false"  \
 "EXT_HALT:false"  \
 "RESET_VECTOR_ADDR_0:0x0"  \

--- a/Training2/Libero/src/components/PF_CCC_C0.tcl
+++ b/Training2/Libero/src/components/PF_CCC_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_CCC_C0
-create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:$PF_CCC_version -component_name {PF_CCC_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:* -component_name {PF_CCC_C0} -params {\
 "DLL_CLK_0_BANKCLK_EN:false"  \
 "DLL_CLK_0_DEDICATED_EN:false"  \
 "DLL_CLK_0_FABCLK_EN:false"  \

--- a/Training2/Libero/src/components/PF_CCC_C1.tcl
+++ b/Training2/Libero/src/components/PF_CCC_C1.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_CCC_C1
-create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:$PF_CCC_version -component_name {PF_CCC_C1} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:* -component_name {PF_CCC_C1} -params {\
 "DLL_CLK_0_BANKCLK_EN:false"  \
 "DLL_CLK_0_DEDICATED_EN:false"  \
 "DLL_CLK_0_FABCLK_EN:false"  \

--- a/Training2/Libero/src/components/PF_CCC_C2.tcl
+++ b/Training2/Libero/src/components/PF_CCC_C2.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_CCC_C2
-create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:$PF_CCC_version -component_name {PF_CCC_C2} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:* -component_name {PF_CCC_C2} -params {\
 "DLL_CLK_0_BANKCLK_EN:false"  \
 "DLL_CLK_0_DEDICATED_EN:false"  \
 "DLL_CLK_0_FABCLK_EN:false"  \

--- a/Training2/Libero/src/components/PF_DDR4_C0.tcl
+++ b/Training2/Libero/src/components/PF_DDR4_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_DDR4_C0
-create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_DDR4:$PF_DDR4_version -component_name {PF_DDR4_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_DDR4:* -component_name {PF_DDR4_C0} -params {\
 "ADDRESS_MIRROR:false" \
 "ADDRESS_ORDERING:CHIP_ROW_BG_BANK_COL" \
 "AUTO_SELF_REFRESH:3" \

--- a/Training2/Libero/src/components/PF_INIT_MONITOR_C0.tcl
+++ b/Training2/Libero/src/components/PF_INIT_MONITOR_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_INIT_MONITOR_C0
-create_and_configure_core -core_vlnv Actel:SgCore:PF_INIT_MONITOR:$PF_INIT_MONITOR_version -component_name {PF_INIT_MONITOR_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_INIT_MONITOR:* -component_name {PF_INIT_MONITOR_C0} -params {\
 "BANK_0_CALIB_STATUS_ENABLED:false"  \
 "BANK_0_CALIB_STATUS_SIMULATION_DELAY:1"  \
 "BANK_0_RECALIBRATION_ENABLED:false"  \

--- a/Training2/Libero/src/components/PF_IOD_GENERIC_RX_C0.tcl
+++ b/Training2/Libero/src/components/PF_IOD_GENERIC_RX_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_IOD_GENERIC_RX_C0
-create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_IOD_GENERIC_RX:$PF_IOD_GENERIC_RX_version -component_name {PF_IOD_GENERIC_RX_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_IOD_GENERIC_RX:* -component_name {PF_IOD_GENERIC_RX_C0} -params {\
 "CLOCK_DELAY_VALUE:0" \
 "DATA_RATE:1200" \
 "DATA_RATIO:8" \

--- a/Training2/Libero/src/components/PF_SRAM_AHBL_AXI_C0.tcl
+++ b/Training2/Libero/src/components/PF_SRAM_AHBL_AXI_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component PF_SRAM_AHBL_AXI_C0
-create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_SRAM_AHBL_AXI:$PF_SRAM_AHBL_AXI_version -component_name {PF_SRAM_AHBL_AXI_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_SRAM_AHBL_AXI:* -component_name {PF_SRAM_AHBL_AXI_C0} -params {\
 "AXI4_AWIDTH:32" \
 "AXI4_DWIDTH:32" \
 "AXI4_IDWIDTH:8" \

--- a/Training2/Libero/src/components/mipicsi2rxdecoderPF_C0.tcl
+++ b/Training2/Libero/src/components/mipicsi2rxdecoderPF_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300TS-1FCG1152I
 # Create and Configure the core component mipicsi2rxdecoderPF_C0
-create_and_configure_core -core_vlnv Microsemi:SolutionCore:mipicsi2rxdecoderPF:$mipicsi2rxdecoderPF_version -component_name {mipicsi2rxdecoderPF_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:SolutionCore:mipicsi2rxdecoderPF:* -component_name {mipicsi2rxdecoderPF_C0} -params {\
 "g_BUFF_DEPTH:1920"  \
 "g_DATAWIDTH:10"  \
 "g_INPUT_DATA_INVERT:0"  \

--- a/Training3/Libero/libero_flow.tcl
+++ b/Training3/Libero/libero_flow.tcl
@@ -2,38 +2,21 @@
 
 new_project -location {./Libero_training3} -name {Libero_training3} -project_description {} -block_mode 0 -hdl Verilog -family {PolarFire} -die {MPF300T} -package {FCG1152} -speed {-1} -die_voltage {1.0} -part_range {EXT} -adv_options {IO_DEFT_STD:LVCMOS 1.8V} -adv_options {RESERVEMIGRATIONPINS:1} -adv_options {RESTRICTPROBEPINS:1} -adv_options {RESTRICTSPIPINS:0} -adv_options {TEMPR:EXT} -adv_options {UNUSED_MSS_IO_RESISTOR_PULL:None} -adv_options {VCCI_1.2_VOLTR:EXT} -adv_options {VCCI_1.5_VOLTR:EXT} -adv_options {VCCI_1.8_VOLTR:EXT} -adv_options {VCCI_2.5_VOLTR:EXT} -adv_options {VCCI_3.3_VOLTR:EXT} -adv_options {VOLTR:EXT} 
 
-#IP core version variables
-set PF_CCC_version 2.2.214
-set CORERESET_PF_version 2.3.100
-set PF_DDR4_version 2.5.108
-set PF_SRAM_AHBL_AXI_version 1.2.108
-set COREFIFO_version 2.7.105
-set COREI2C_version 7.2.101
-set CoreAPB3_version 4.1.100
-set CoreGPIO_version 3.2.102
-set COREJTAGDEBUG_version 3.1.100
-set PF_INIT_MONITOR_version 2.0.304
-set MIV_RV32_version 3.0.100
-set CoreUARTapb_version 5.6.102
-set COREAXI4INTERCONNECT_version 2.8.103
-set COREAXITOAXICONNECT_version 2.0.101
-
-
 #Download all the required cores to the vault
-download_core -vlnv "Actel:SgCore:PF_CCC:${PF_CCC_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Actel:DirectCore:CORERESET_PF:${CORERESET_PF_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:SystemBuilder:PF_DDR4:${PF_DDR4_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Actel:SystemBuilder:PF_SRAM_AHBL_AXI:${PF_SRAM_AHBL_AXI_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Actel:DirectCore:COREFIFO:${COREFIFO_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:COREI2C:${COREI2C_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:CoreAPB3:${CoreAPB3_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:CoreGPIO:${CoreGPIO_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:COREJTAGDEBUG:${COREJTAGDEBUG_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:SgCore:PF_INIT_MONITOR:${PF_INIT_MONITOR_version}" -location {www.microchip-ip.com/repositories/SgCore}
-download_core -vlnv "Microsemi:MiV:MIV_RV32:${MIV_RV32_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:CoreUARTapb:${CoreUARTapb_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:COREAXI4INTERCONNECT:${COREAXI4INTERCONNECT_version}" -location {www.microchip-ip.com/repositories/DirectCore}
-download_core -vlnv "Actel:DirectCore:COREAXITOAXICONNECT:${COREAXITOAXICONNECT_version}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:SgCore:PF_CCC:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Actel:DirectCore:CORERESET_PF:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:SystemBuilder:PF_DDR4:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Actel:SystemBuilder:PF_SRAM_AHBL_AXI:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Actel:DirectCore:COREFIFO:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:COREI2C:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:CoreAPB3:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:CoreGPIO:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:COREJTAGDEBUG:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:SgCore:PF_INIT_MONITOR:*}" -location {www.microchip-ip.com/repositories/SgCore}
+download_core -vlnv "Microsemi:MiV:MIV_RV32:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:CoreUARTapb:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:COREAXI4INTERCONNECT:*}" -location {www.microchip-ip.com/repositories/DirectCore}
+download_core -vlnv "Actel:DirectCore:COREAXITOAXICONNECT:*}" -location {www.microchip-ip.com/repositories/DirectCore}
 
 #source the below tcl file to create the top level SmartDesign and generate it
 source ./src/TOP_recursive.tcl

--- a/Training3/Libero/src/components/COREAXI4INTERCONNECT_C0.tcl
+++ b/Training3/Libero/src/components/COREAXI4INTERCONNECT_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component COREAXI4INTERCONNECT_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:COREAXI4INTERCONNECT:$COREAXI4INTERCONNECT_version -component_name {COREAXI4INTERCONNECT_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:COREAXI4INTERCONNECT:* -component_name {COREAXI4INTERCONNECT_C0} -params {\
 "ADDR_WIDTH:32"  \
 "CROSSBAR_MODE:0"  \
 "DATA_WIDTH:64"  \

--- a/Training3/Libero/src/components/COREAXI4INTERCONNECT_C1.tcl
+++ b/Training3/Libero/src/components/COREAXI4INTERCONNECT_C1.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component COREAXI4INTERCONNECT_C1
-create_and_configure_core -core_vlnv Actel:DirectCore:COREAXI4INTERCONNECT:$COREAXI4INTERCONNECT_version -component_name {COREAXI4INTERCONNECT_C1} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:COREAXI4INTERCONNECT:* -component_name {COREAXI4INTERCONNECT_C1} -params {\
 "ADDR_WIDTH:32"  \
 "CROSSBAR_MODE:0"  \
 "DATA_WIDTH:64"  \

--- a/Training3/Libero/src/components/COREAXITOAXICONNECT_C1.tcl
+++ b/Training3/Libero/src/components/COREAXITOAXICONNECT_C1.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component COREAXITOAXICONNECT_C1
-create_and_configure_core -core_vlnv Actel:DirectCore:COREAXITOAXICONNECT:$COREAXITOAXICONNECT_version -component_name {COREAXITOAXICONNECT_C1} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:COREAXITOAXICONNECT:* -component_name {COREAXITOAXICONNECT_C1} -params {\
 "SLAVE_ADDR_WIDTH:32"  \
 "SLAVE_DATA_WIDTH:64"  \
 "SLAVE_ID_WIDTH:1"  \

--- a/Training3/Libero/src/components/COREFIFO_C0.tcl
+++ b/Training3/Libero/src/components/COREFIFO_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component COREFIFO_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:COREFIFO:$COREFIFO_version -component_name {COREFIFO_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:COREFIFO:* -component_name {COREFIFO_C0} -params {\
 "AE_STATIC_EN:false"  \
 "AEVAL:4"  \
 "AF_STATIC_EN:false"  \

--- a/Training3/Libero/src/components/COREI2C_C0.tcl
+++ b/Training3/Libero/src/components/COREI2C_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component COREI2C_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:COREI2C:$COREI2C_version -component_name {COREI2C_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:COREI2C:* -component_name {COREI2C_C0} -params {\
 "ADD_SLAVE1_ADDRESS_EN:false"  \
 "BAUD_RATE_FIXED:false"  \
 "BAUD_RATE_VALUE:0"  \

--- a/Training3/Libero/src/components/COREJTAGDEBUG_C0.tcl
+++ b/Training3/Libero/src/components/COREJTAGDEBUG_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component COREJTAGDEBUG_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:COREJTAGDEBUG:$COREJTAGDEBUG_version -component_name {COREJTAGDEBUG_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:COREJTAGDEBUG:* -component_name {COREJTAGDEBUG_C0} -params {\
 "IR_CODE_TGT_0:0x55"  \
 "IR_CODE_TGT_1:0x56"  \
 "IR_CODE_TGT_2:0x57"  \

--- a/Training3/Libero/src/components/CORERESET_PF_C0.tcl
+++ b/Training3/Libero/src/components/CORERESET_PF_C0.tcl
@@ -2,5 +2,5 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component CORERESET_PF_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:$CORERESET_PF_version -component_name {CORERESET_PF_C0} -params { }
+create_and_configure_core -core_vlnv Actel:DirectCore:CORERESET_PF:* -component_name {CORERESET_PF_C0} -params { }
 # Exporting Component Description of CORERESET_PF_C0 to TCL done

--- a/Training3/Libero/src/components/CoreAPB3_C0.tcl
+++ b/Training3/Libero/src/components/CoreAPB3_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component CoreAPB3_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:CoreAPB3:$CoreAPB3_version -component_name {CoreAPB3_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CoreAPB3:* -component_name {CoreAPB3_C0} -params {\
 "APB_DWIDTH:32"  \
 "APBSLOT0ENABLE:true"  \
 "APBSLOT1ENABLE:true"  \

--- a/Training3/Libero/src/components/CoreGPIO_C0.tcl
+++ b/Training3/Libero/src/components/CoreGPIO_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component CoreGPIO_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:CoreGPIO:$CoreGPIO_version -component_name {CoreGPIO_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CoreGPIO:* -component_name {CoreGPIO_C0} -params {\
 "APB_WIDTH:32"  \
 "FIXED_CONFIG_0:true"  \
 "FIXED_CONFIG_1:true"  \

--- a/Training3/Libero/src/components/CoreUARTapb_C0.tcl
+++ b/Training3/Libero/src/components/CoreUARTapb_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component CoreUARTapb_C0
-create_and_configure_core -core_vlnv Actel:DirectCore:CoreUARTapb:$CoreUARTapb_version -component_name {CoreUARTapb_C0} -params {\
+create_and_configure_core -core_vlnv Actel:DirectCore:CoreUARTapb:* -component_name {CoreUARTapb_C0} -params {\
 "BAUD_VAL_FRCTN:0"  \
 "BAUD_VAL_FRCTN_EN:false"  \
 "BAUD_VALUE:1"  \

--- a/Training3/Libero/src/components/MIV_RAM_64K.tcl
+++ b/Training3/Libero/src/components/MIV_RAM_64K.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component MIV_RAM_64K
-create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_SRAM_AHBL_AXI:$PF_SRAM_AHBL_AXI_version -component_name {MIV_RAM_64K} -params {\
+create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_SRAM_AHBL_AXI:* -component_name {MIV_RAM_64K} -params {\
 "AXI4_AWIDTH:32" \
 "AXI4_DWIDTH:32" \
 "AXI4_IDWIDTH:8" \

--- a/Training3/Libero/src/components/MIV_RV32_C0.tcl
+++ b/Training3/Libero/src/components/MIV_RV32_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component MIV_RV32_C0
-create_and_configure_core -core_vlnv Microsemi:MiV:MIV_RV32:$MIV_RV32_version -component_name {MIV_RV32_C0} -params {\
+create_and_configure_core -core_vlnv Microsemi:MiV:MIV_RV32:* -component_name {MIV_RV32_C0} -params {\
 "AHB_END_ADDR_0:0xffff"  \
 "AHB_END_ADDR_1:0x8fff"  \
 "AHB_MASTER_TYPE:1"  \

--- a/Training3/Libero/src/components/PF_CCC_C0.tcl
+++ b/Training3/Libero/src/components/PF_CCC_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component PF_CCC_C0
-create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:$PF_CCC_version -component_name {PF_CCC_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:* -component_name {PF_CCC_C0} -params {\
 "DLL_CLK_0_BANKCLK_EN:false"  \
 "DLL_CLK_0_DEDICATED_EN:false"  \
 "DLL_CLK_0_FABCLK_EN:false"  \

--- a/Training3/Libero/src/components/PF_CCC_C1.tcl
+++ b/Training3/Libero/src/components/PF_CCC_C1.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component PF_CCC_C1
-create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:$PF_CCC_version -component_name {PF_CCC_C1} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_CCC:* -component_name {PF_CCC_C1} -params {\
 "DLL_CLK_0_BANKCLK_EN:false"  \
 "DLL_CLK_0_DEDICATED_EN:false"  \
 "DLL_CLK_0_FABCLK_EN:false"  \

--- a/Training3/Libero/src/components/PF_DDR4_C0.tcl
+++ b/Training3/Libero/src/components/PF_DDR4_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component PF_DDR4_C0
-create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_DDR4:$PF_DDR4_version -component_name {PF_DDR4_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SystemBuilder:PF_DDR4:* -component_name {PF_DDR4_C0} -params {\
 "ADDRESS_MIRROR:false" \
 "ADDRESS_ORDERING:CHIP_ROW_BG_BANK_COL" \
 "AUTO_SELF_REFRESH:3" \

--- a/Training3/Libero/src/components/PF_INIT_MONITOR_C0.tcl
+++ b/Training3/Libero/src/components/PF_INIT_MONITOR_C0.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFire
 # Part Number: MPF300T-1FCG1152E
 # Create and Configure the core component PF_INIT_MONITOR_C0
-create_and_configure_core -core_vlnv Actel:SgCore:PF_INIT_MONITOR:$PF_INIT_MONITOR_version -component_name {PF_INIT_MONITOR_C0} -params {\
+create_and_configure_core -core_vlnv Actel:SgCore:PF_INIT_MONITOR:* -component_name {PF_INIT_MONITOR_C0} -params {\
 "BANK_0_CALIB_STATUS_ENABLED:false"  \
 "BANK_0_CALIB_STATUS_SIMULATION_DELAY:1"  \
 "BANK_0_RECALIBRATION_ENABLED:false"  \


### PR DESCRIPTION
Before, we specify a specific version for each Libero core. Now I update all the download_core and create_and_configure_core commands to use "*" to always use the latest core version. Moving forward, if the cores are deprecated by Libero, we don't need to updte the core version anymore, the design will automatically use the latest core versions.

Also update README.txt to remove the comment about updating Libero core versions.