### PR TITLE
Update the Libero core version for the 3 SmartHLS trainings for the 2…

### DIFF
--- a/Training1/Libero/libero_flow.tcl
+++ b/Training1/Libero/libero_flow.tcl
@@ -2,27 +2,27 @@
 
 new_project -location {./Libero_training1} -name {Libero_training1} -project_description {} -block_mode 0 -hdl Verilog -family {PolarFire} -die {MPF300TS} -package {FCG1152} -speed {-1} -die_voltage {1.0} -part_range {IND} -adv_options {IO_DEFT_STD:LVCMOS 1.8V} -adv_options {RESERVEMIGRATIONPINS:1} -adv_options {RESTRICTPROBEPINS:1} -adv_options {RESTRICTSPIPINS:0} -adv_options {TEMPR:IND} -adv_options {UNUSED_MSS_IO_RESISTOR_PULL:None} -adv_options {VCCI_1.2_VOLTR:IND} -adv_options {VCCI_1.5_VOLTR:IND} -adv_options {VCCI_1.8_VOLTR:IND} -adv_options {VCCI_2.5_VOLTR:IND} -adv_options {VCCI_3.3_VOLTR:IND} -adv_options {VOLTR:IND} 
 
-set PF_CCC_version 2.2.214
+set PF_CCC_version 2.2.220
 set Display_Controller_version 3.1.2
-set HDMI_RX_version  4.2.0
-set HDMI_TX_version  1.0.2
-set PF_TX_PLL_version  2.0.300
-set PF_XCVR_ERM_version  3.1.200
-set PF_XCVR_REF_CLK_version  1.0.103
-set CORERESET_PF_version  2.2.107
-set CORERXIODBITALIGN_version  2.1.104
-set PF_IOD_GENERIC_RX_version  2.1.109
-set PF_DDR4_version  2.5.108
-set PF_SRAM_AHBL_AXI_version  1.2.108
-set mipicsi2rxdecoderPF_version  2.2.5
-set COREAHBTOAPB3_version  3.1.100
-set COREI2C_version  7.2.101
-set CoreAPB3_version  4.1.100
-set CoreGPIO_version  3.2.102
-set COREJTAGDEBUG_version  3.1.100
-set CoreAHBLite_version  5.4.102
-set PF_INIT_MONITOR_version  2.0.304
-set MIV_RV32IMA_L1_AHB_version  2.3.100
+set HDMI_RX_version 4.2.0
+set HDMI_TX_version 1.0.2
+set PF_TX_PLL_version 2.0.300
+set PF_XCVR_ERM_version 3.1.200
+set PF_XCVR_REF_CLK_version 1.0.103
+set CORERESET_PF_version 2.2.107
+set CORERXIODBITALIGN_version 2.1.104
+set PF_IOD_GENERIC_RX_version 2.1.110
+set PF_DDR4_version 2.5.109
+set PF_SRAM_AHBL_AXI_version 1.2.110
+set mipicsi2rxdecoderPF_version 2.2.5
+set COREAHBTOAPB3_version 3.1.100
+set COREI2C_version 7.2.101
+set CoreAPB3_version 4.1.100
+set CoreGPIO_version 3.2.102
+set COREJTAGDEBUG_version 3.1.100
+set CoreAHBLite_version 5.4.102
+set PF_INIT_MONITOR_version 2.0.304
+set MIV_RV32IMA_L1_AHB_version 2.3.100
 set COREUART_version 5.6.102
 set Bayer_Interpolation_version 3.0.2
 set Image_Enhancement_version 3.0.0

--- a/Training2/Libero/libero_flow.tcl
+++ b/Training2/Libero/libero_flow.tcl
@@ -2,22 +2,22 @@
 
 new_project -location {./Libero_training2} -name {Libero_training2} -project_description {} -block_mode 0 -hdl Verilog -family {PolarFire} -die {MPF300TS} -package {FCG1152} -speed {-1} -die_voltage {1.0} -part_range {IND} -adv_options {IO_DEFT_STD:LVCMOS 1.8V} -adv_options {RESERVEMIGRATIONPINS:1} -adv_options {RESTRICTPROBEPINS:1} -adv_options {RESTRICTSPIPINS:0} -adv_options {TEMPR:IND} -adv_options {UNUSED_MSS_IO_RESISTOR_PULL:None} -adv_options {VCCI_1.2_VOLTR:IND} -adv_options {VCCI_1.5_VOLTR:IND} -adv_options {VCCI_1.8_VOLTR:IND} -adv_options {VCCI_2.5_VOLTR:IND} -adv_options {VCCI_3.3_VOLTR:IND} -adv_options {VOLTR:IND} 
 
-set PF_CCC_version 2.2.214
+set PF_CCC_version 2.2.220
 set Display_Controller_version 3.1.2
-set CORERESET_PF_version  2.2.107
-set CORERXIODBITALIGN_version  2.1.104
-set PF_IOD_GENERIC_RX_version  2.1.109
-set PF_DDR4_version  2.5.108
-set PF_SRAM_AHBL_AXI_version  1.2.108
-set mipicsi2rxdecoderPF_version  2.2.5
-set COREAHBTOAPB3_version  3.1.100
-set COREI2C_version  7.2.101
-set CoreAPB3_version  4.1.100
-set CoreGPIO_version  3.2.102
-set COREJTAGDEBUG_version  3.1.100
-set CoreAHBLite_version  5.4.102
-set PF_INIT_MONITOR_version  2.0.304
-set MIV_RV32IMA_L1_AHB_version  2.3.100
+set CORERESET_PF_version 2.2.107
+set CORERXIODBITALIGN_version 2.1.104
+set PF_IOD_GENERIC_RX_version 2.1.110
+set PF_DDR4_version 2.5.109
+set PF_SRAM_AHBL_AXI_version 1.2.110
+set mipicsi2rxdecoderPF_version 2.2.5
+set COREAHBTOAPB3_version 3.1.100
+set COREI2C_version 7.2.101
+set CoreAPB3_version 4.1.100
+set CoreGPIO_version 3.2.102
+set COREJTAGDEBUG_version 3.1.100
+set CoreAHBLite_version 5.4.102
+set PF_INIT_MONITOR_version 2.0.304
+set MIV_RV32IMA_L1_AHB_version 2.3.100
 set COREUART_version 5.6.102
 set Bayer_Interpolation_version 3.0.2
 set Image_Enhancement_version 3.0.0

--- a/Training3/Libero/libero_flow.tcl
+++ b/Training3/Libero/libero_flow.tcl
@@ -3,10 +3,10 @@
 new_project -location {./Libero_training3} -name {Libero_training3} -project_description {} -block_mode 0 -hdl Verilog -family {PolarFire} -die {MPF300T} -package {FCG1152} -speed {-1} -die_voltage {1.0} -part_range {EXT} -adv_options {IO_DEFT_STD:LVCMOS 1.8V} -adv_options {RESERVEMIGRATIONPINS:1} -adv_options {RESTRICTPROBEPINS:1} -adv_options {RESTRICTSPIPINS:0} -adv_options {TEMPR:EXT} -adv_options {UNUSED_MSS_IO_RESISTOR_PULL:None} -adv_options {VCCI_1.2_VOLTR:EXT} -adv_options {VCCI_1.5_VOLTR:EXT} -adv_options {VCCI_1.8_VOLTR:EXT} -adv_options {VCCI_2.5_VOLTR:EXT} -adv_options {VCCI_3.3_VOLTR:EXT} -adv_options {VOLTR:EXT} 
 
 #IP core version variables
-set PF_CCC_version 2.2.214
+set PF_CCC_version 2.2.220
 set CORERESET_PF_version 2.3.100
-set PF_DDR4_version 2.5.108
-set PF_SRAM_AHBL_AXI_version 1.2.108
+set PF_DDR4_version 2.5.109
+set PF_SRAM_AHBL_AXI_version 1.2.110
 set COREFIFO_version 2.7.105
 set COREI2C_version 7.2.101
 set CoreAPB3_version 4.1.100


### PR DESCRIPTION
…022.3 release

The following cores were deprecated and need to be updated, otherwise the design will fail to run with a fresh vault:
- PF_CCC
- PF_IOD_GENERIC_RX
- PF_DDR4
- PF_SRAM_AHBL_AXI

These cores are updated by changing the version specified in the script `libero_flow.tcl` to use "*". From now on, these cores will always be `download_core` and `create_and_configure_core` at the latest version.

All other cores are currently left unchanged at the current version. In the future, if some of these cores were deprecated, we'll need to update our scripts. The idea is that for this commit, we'll only change the smallest set of cores that break the flow. If we update all cores to use the latest version, there might be other unforeseen consequences that might require a lot of effort to fix.

Testing: I tested locally on my Linux machine with Libero capture 2022_3_0_5_agni and a fresh vault. The 3 trainings can run `libero_flow.tcl` correctly.