### PR TITLE
Don't change line endings of .sh scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# don't modify line endings of bash scripts
+*.sh          text eol=lf


### PR DESCRIPTION
Native Windows git adds \r which causes problems for bash scripts
Cygwin's Git does not have this problem, but has issue with git lfs