### PR TITLE
Canny fifo dataflow update

### DIFF
--- a/Training1/Canny/canny.cpp
+++ b/Training1/Canny/canny.cpp
@@ -6,6 +6,7 @@
 void canny(hls::FIFO<unsigned char> &input_fifo,
            hls::FIFO<unsigned char> &output_fifo) {
 #pragma HLS function top
+#pragma HLS function dataflow
 
     hls::FIFO<unsigned char> output_fifo_gf(/* depth = */ 2);
     hls::FIFO<unsigned short> output_fifo_sf(/* depth = */ 2);

--- a/Training1/Canny_FIFO_Switch/canny.cpp
+++ b/Training1/Canny_FIFO_Switch/canny.cpp
@@ -10,6 +10,7 @@ void canny(hls::FIFO<hls::ap_uint<1>> &switch_fifo_0,
            hls::FIFO<unsigned char> &input_fifo,
            hls::FIFO<unsigned char> &output_fifo) {
 #pragma HLS function top
+#pragma HLS function dataflow
 
     hls::FIFO<unsigned char> output_fifo_gf(/* depth = */ 2);
     hls::FIFO<unsigned short> output_fifo_sf(/* depth = */ 2);

--- a/Training1/Canny_FIFO_Switch/canny.cpp
+++ b/Training1/Canny_FIFO_Switch/canny.cpp
@@ -3,10 +3,10 @@
 
 #include <assert.h>
 
-void canny(hls::FIFO<hls::ap_uint<1>> &switch_fifo_0,
-           hls::FIFO<hls::ap_uint<1>> &switch_fifo_1,
-           hls::FIFO<hls::ap_uint<1>> &switch_fifo_2,
-           hls::FIFO<hls::ap_uint<1>> &switch_fifo_3,
+void canny(bool switch_0,
+           bool switch_1,
+           bool switch_2,
+           bool switch_3,
            hls::FIFO<unsigned char> &input_fifo,
            hls::FIFO<unsigned char> &output_fifo) {
 #pragma HLS function top
@@ -16,19 +16,19 @@ void canny(hls::FIFO<hls::ap_uint<1>> &switch_fifo_0,
     hls::FIFO<unsigned short> output_fifo_sf(/* depth = */ 2);
     hls::FIFO<unsigned char> output_fifo_nm(/* depth = */ 2);
 
-    gaussian_filter(switch_fifo_0, input_fifo, output_fifo_gf);
-    sobel_filter(switch_fifo_1, output_fifo_gf, output_fifo_sf);
-    nonmaximum_suppression(switch_fifo_2, output_fifo_sf, output_fifo_nm);
-    hysteresis_filter(switch_fifo_3, output_fifo_nm, output_fifo);
+    gaussian_filter(switch_0, input_fifo, output_fifo_gf);
+    sobel_filter(switch_1, output_fifo_gf, output_fifo_sf);
+    nonmaximum_suppression(switch_2, output_fifo_sf, output_fifo_nm);
+    hysteresis_filter(switch_3, output_fifo_nm, output_fifo);
 }
 
 int main() {
     unsigned int i, j;
 
-    hls::FIFO<hls::ap_uint<1>> switch_fifo_0(/* depth = */ WIDTH * HEIGHT * 2);
-    hls::FIFO<hls::ap_uint<1>> switch_fifo_1(/* depth = */ WIDTH * HEIGHT * 2);
-    hls::FIFO<hls::ap_uint<1>> switch_fifo_2(/* depth = */ WIDTH * HEIGHT * 2);
-    hls::FIFO<hls::ap_uint<1>> switch_fifo_3(/* depth = */ WIDTH * HEIGHT * 2);
+    bool switch_0;
+    bool switch_1;
+    bool switch_2;
+    bool switch_3;
     hls::FIFO<unsigned char> input_fifo(/* depth = */ WIDTH * HEIGHT * 2);
     hls::FIFO<unsigned char> output_fifo(/* depth = */ WIDTH * HEIGHT * 2);
 
@@ -75,20 +75,19 @@ int main() {
     nm_sw(sobel_output, nonmaximum_suppression_output);
     hf_sw(nonmaximum_suppression_output, hysteresis_output_golden);
 
-    const hls::ap_uint<1> on = 1;
     // Write test input pixels.
     for (i = 0; i < HEIGHT; i++) {
         for (j = 0; j < WIDTH; j++) {
-            switch_fifo_0.write(on);
-            switch_fifo_1.write(on);
-            switch_fifo_2.write(on);
-            switch_fifo_3.write(on);
+            switch_0 = true;
+            switch_1 = true;
+            switch_2 = true;
+            switch_3 = true;
             unsigned char r = input_channel->r;
             unsigned char g = input_channel->g;
             unsigned char b = input_channel->b;
             unsigned grayscale = (r + g + b) / 3;
             input_fifo.write(grayscale);
-            canny(switch_fifo_0, switch_fifo_1, switch_fifo_2, switch_fifo_3,
+            canny(switch_0, switch_1, switch_2, switch_3,
                   input_fifo, output_fifo);
             input_channel++;
         }
@@ -96,12 +95,12 @@ int main() {
 
     // Give more inputs to flush out all pixels.
     for (i = 0; i < GF_KERNEL_SIZE * WIDTH + GF_KERNEL_SIZE; i++) {
-        switch_fifo_0.write(on);
-        switch_fifo_1.write(on);
-        switch_fifo_2.write(on);
-        switch_fifo_3.write(on);
+        switch_0 = true;
+        switch_1 = true;
+        switch_2 = true;
+        switch_3 = true;
         input_fifo.write(0);
-        canny(switch_fifo_0, switch_fifo_1, switch_fifo_2, switch_fifo_3,
+        canny(switch_0, switch_1, switch_2, switch_3,
               input_fifo, output_fifo);
     }
 

--- a/Training1/Canny_FIFO_Switch/define.hpp
+++ b/Training1/Canny_FIFO_Switch/define.hpp
@@ -25,7 +25,7 @@ void window_and_line_buffer(hls::ap_uint<10> input,
 
 // Gaussian Filter.
 const unsigned int GF_KERNEL_SIZE = 5;
-void gaussian_filter(hls::FIFO<hls::ap_uint<1>> &switch_fifo,
+void gaussian_filter(bool on_switch,
                      hls::FIFO<unsigned char> &input_fifo,
                      hls::FIFO<unsigned char> &output_fifo);
 void gf_sw(unsigned char input[][WIDTH], unsigned char output[][WIDTH]);
@@ -33,13 +33,13 @@ void gf_sw(unsigned char input[][WIDTH], unsigned char output[][WIDTH]);
 // Sobel Filter.
 const unsigned int SF_KERNEL_SIZE = 3;
 void sf_sw(unsigned char input[][WIDTH], hls::ap_uint<10> output[][WIDTH]);
-void sobel_filter(hls::FIFO<hls::ap_uint<1>> &switch_fifo,
+void sobel_filter(bool on_switch,
                   hls::FIFO<unsigned char> &input_fifo,
                   hls::FIFO<unsigned short> &output_fifo);
 
 // Non-maximum suppression.
 const unsigned int NM_KERNEL_SIZE = 3;
-void nonmaximum_suppression(hls::FIFO<hls::ap_uint<1>> &switch_fifo,
+void nonmaximum_suppression(bool on_switch,
                             hls::FIFO<unsigned short> &input_fifo,
                             hls::FIFO<unsigned char> &output_fifo);
 void nm_sw(hls::ap_uint<10> input[][WIDTH], unsigned char output[][WIDTH]);
@@ -47,7 +47,7 @@ void nm_sw(hls::ap_uint<10> input[][WIDTH], unsigned char output[][WIDTH]);
 // Hysteresis filter.
 const unsigned int HF_KERNEL_SIZE = 3;
 void hf_sw(unsigned char input[][WIDTH], unsigned char output[][WIDTH]);
-void hysteresis_filter(hls::FIFO<hls::ap_uint<1>> &switch_fifo,
+void hysteresis_filter(bool on_switch,
                        hls::FIFO<unsigned char> &input_fifo,
                        hls::FIFO<unsigned char> &output_fifo);
 

--- a/Training1/Canny_FIFO_Switch/gaussian_filter.cpp
+++ b/Training1/Canny_FIFO_Switch/gaussian_filter.cpp
@@ -10,7 +10,7 @@ const unsigned int GAUSSIAN[GF_KERNEL_SIZE]
                                                {1, 3, 4, 3, 1}};
 const unsigned int DIVISOR = 128;
 
-void gaussian_filter(hls::FIFO<hls::ap_uint<1>> &switch_fifo,
+void gaussian_filter(bool on_switch,
                      hls::FIFO<unsigned char> &input_fifo,
                      hls::FIFO<unsigned char> &output_fifo) {
     #pragma HLS function pipeline
@@ -46,10 +46,9 @@ void gaussian_filter(hls::FIFO<hls::ap_uint<1>> &switch_fifo,
     unsigned char current_pixel = line_buffer.window[center][center];
 
     // if filter is off, pass pixel through
-    bool on = switch_fifo.read();
-    if (!on) {
-    	output_fifo.write(current_pixel);
-    	return;
+    if (!on_switch) {
+        output_fifo.write(current_pixel);
+        return;
     }
 
     if (outofbounds) {

--- a/Training1/Canny_FIFO_Switch/hysteresis_filter.cpp
+++ b/Training1/Canny_FIFO_Switch/hysteresis_filter.cpp
@@ -1,7 +1,7 @@
 #include "define.hpp"
 #include <hls/image_processing.hpp>
 
-void hysteresis_filter(hls::FIFO<hls::ap_uint<1>> &switch_fifo,
+void hysteresis_filter(bool on_switch,
                        hls::FIFO<unsigned char> &input_fifo,
                        hls::FIFO<unsigned char> &output_fifo) {
 #pragma HLS function pipeline
@@ -37,8 +37,7 @@ void hysteresis_filter(hls::FIFO<hls::ap_uint<1>> &switch_fifo,
     unsigned char current_pixel = line_buffer.window[center][center];
 
     // if filter is off, pass pixel through
-    bool on = switch_fifo.read();
-    if (!on) {
+    if (!on_switch) {
         output_fifo.write(current_pixel);
         return;
     }

--- a/Training1/Canny_FIFO_Switch/nonmaximum_suppression.cpp
+++ b/Training1/Canny_FIFO_Switch/nonmaximum_suppression.cpp
@@ -1,8 +1,8 @@
 #include "define.hpp"
 #include <hls/image_processing.hpp>
 
-void nonmaximum_suppression(hls::FIFO<hls::ap_uint<1>> &switch_fifo,
-		                    hls::FIFO<unsigned short> &input_fifo,
+void nonmaximum_suppression(bool on_switch,
+                            hls::FIFO<unsigned short> &input_fifo,
                             hls::FIFO<unsigned char> &output_fifo) {
     #pragma HLS function pipeline
 
@@ -36,12 +36,11 @@ void nonmaximum_suppression(hls::FIFO<hls::ap_uint<1>> &switch_fifo,
     unsigned int center = NM_KERNEL_SIZE / 2;
     int current_pixel = (int)line_buffer.window[center][center] & 0xff;
 
-	// if filter is off, pass pixel through
-    bool on = switch_fifo.read();
-    if (!on) {
-		output_fifo.write(current_pixel);
-		return;
-	}
+    // if filter is off, pass pixel through
+    if (!on_switch) {
+        output_fifo.write(current_pixel);
+        return;
+    }
 
     if (outofbounds) {
         output_fifo.write(current_pixel);

--- a/Training1/Canny_FIFO_Switch/sobel_filter.cpp
+++ b/Training1/Canny_FIFO_Switch/sobel_filter.cpp
@@ -6,8 +6,8 @@ const int GX[SF_KERNEL_SIZE]
 const int GY[SF_KERNEL_SIZE]
             [SF_KERNEL_SIZE] = {{1, 2, 1}, {0, 0, 0}, {-1, -2, -1}};
 
-void sobel_filter(hls::FIFO<hls::ap_uint<1>> &switch_fifo,
-		          hls::FIFO<unsigned char> &input_fifo,
+void sobel_filter(bool on_switch,
+                  hls::FIFO<unsigned char> &input_fifo,
                   hls::FIFO<unsigned short> &output_fifo) {
     #pragma HLS function pipeline
 
@@ -42,8 +42,7 @@ void sobel_filter(hls::FIFO<hls::ap_uint<1>> &switch_fifo,
     unsigned char current_pixel = line_buffer.window[center][center];
 
     // if filter is off, pass pixel through
-    bool on = switch_fifo.read();
-    if (!on) {
+    if (!on_switch) {
         output_fifo.write(current_pixel);
         return;
     }

--- a/Training1/Libero/src/components/LegUp_Image_Filters.tcl
+++ b/Training1/Libero/src/components/LegUp_Image_Filters.tcl
@@ -50,23 +50,11 @@ sd_show_bif_pins -sd_name ${sd_name} -bif_pin_name {canny_top_0:input_fifo_axi4s
 sd_show_bif_pins -sd_name ${sd_name} -bif_pin_name {canny_top_0:output_fifo_axi4stream} -pin_names {canny_top_0:output_fifo}
 sd_show_bif_pins -sd_name ${sd_name} -bif_pin_name {canny_top_0:output_fifo_axi4stream} -pin_names {canny_top_0:output_fifo_ready}
 sd_show_bif_pins -sd_name ${sd_name} -bif_pin_name {canny_top_0:output_fifo_axi4stream} -pin_names {canny_top_0:output_fifo_valid}
-sd_show_bif_pins -sd_name ${sd_name} -bif_pin_name {canny_top_0:switch_fifo_0_axi4stream} -pin_names {canny_top_0:switch_fifo_0}
-sd_show_bif_pins -sd_name ${sd_name} -bif_pin_name {canny_top_0:switch_fifo_0_axi4stream} -pin_names {canny_top_0:switch_fifo_0_valid}
-sd_show_bif_pins -sd_name ${sd_name} -bif_pin_name {canny_top_0:switch_fifo_1_axi4stream} -pin_names {canny_top_0:switch_fifo_1}
-sd_show_bif_pins -sd_name ${sd_name} -bif_pin_name {canny_top_0:switch_fifo_1_axi4stream} -pin_names {canny_top_0:switch_fifo_1_valid}
-sd_show_bif_pins -sd_name ${sd_name} -bif_pin_name {canny_top_0:switch_fifo_2_axi4stream} -pin_names {canny_top_0:switch_fifo_2}
-sd_show_bif_pins -sd_name ${sd_name} -bif_pin_name {canny_top_0:switch_fifo_2_axi4stream} -pin_names {canny_top_0:switch_fifo_2_valid}
-sd_show_bif_pins -sd_name ${sd_name} -bif_pin_name {canny_top_0:switch_fifo_3_axi4stream} -pin_names {canny_top_0:switch_fifo_3}
-sd_show_bif_pins -sd_name ${sd_name} -bif_pin_name {canny_top_0:switch_fifo_3_axi4stream} -pin_names {canny_top_0:switch_fifo_3_valid}
 sd_invert_pins -sd_name ${sd_name} -pin_names {canny_top_0:reset}
 sd_connect_pins_to_constant -sd_name ${sd_name} -pin_names {canny_top_0:start} -value {VCC}
 sd_mark_pins_unused -sd_name ${sd_name} -pin_names {canny_top_0:ready}
 sd_mark_pins_unused -sd_name ${sd_name} -pin_names {canny_top_0:finish}
-sd_connect_pins_to_constant -sd_name ${sd_name} -pin_names {canny_top_0:switch_fifo_0_valid} -value {VCC}
-sd_connect_pins_to_constant -sd_name ${sd_name} -pin_names {canny_top_0:switch_fifo_3_valid} -value {VCC}
 sd_connect_pins_to_constant -sd_name ${sd_name} -pin_names {canny_top_0:output_fifo_ready} -value {VCC}
-sd_connect_pins_to_constant -sd_name ${sd_name} -pin_names {canny_top_0:switch_fifo_2_valid} -value {VCC}
-sd_connect_pins_to_constant -sd_name ${sd_name} -pin_names {canny_top_0:switch_fifo_1_valid} -value {VCC}
 
 
 
@@ -157,10 +145,10 @@ sd_connect_pins -sd_name ${sd_name} -pin_names {"AND2_0:Y" "video_fifo_0:rresetn
 sd_connect_pins -sd_name ${sd_name} -pin_names {"canny_top_0:clk" "clk" "delay_0:clk" "gaussian_filter_pipelined_top_0:clk" "switch_3_state_controller_top_0:clk" "video_fifo_0:rclock_i" "video_fifo_0:wclock_i" "video_fifo_1:rclock_i" "video_fifo_1:wclock_i" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"canny_top_0:input_fifo_valid" "gaussian_filter_pipelined_top_0:input_fifo_valid" "input_valid" "video_fifo_0:wen_i" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"canny_top_0:output_fifo_valid" "delay_0:valid_i" "video_fifo_0:ren_i" "video_fifo_1:ren_i" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"canny_top_0:switch_fifo_0" "gaussian_filter_pipelined_top_0:on_switch" "switches[0:0]" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"canny_top_0:switch_fifo_1" "switches[1:1]" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"canny_top_0:switch_fifo_2" "switches[2:2]" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"canny_top_0:switch_fifo_3" "switches[3:3]" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"canny_top_0:switch_0" "gaussian_filter_pipelined_top_0:on_switch" "switches[0:0]" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"canny_top_0:switch_1" "switches[1:1]" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"canny_top_0:switch_2" "switches[2:2]" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"canny_top_0:switch_3" "switches[3:3]" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"delay_0:valid_o" "output_valid" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"gaussian_filter_pipelined_top_0:output_fifo_valid" "video_fifo_1:wen_i" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"switch_3_state_controller_top_0:toggle" "toggle" }

--- a/fp_mult/fmult_test.cpp
+++ b/fp_mult/fmult_test.cpp
@@ -170,6 +170,7 @@ void custom_top(FIFO<ap_uint<16>> &half_ina,
                 FIFO<unsigned> &float_inb,
                 FIFO<unsigned> &float_out) {
 #pragma HLS function top
+#pragma HLS function dataflow
     fmult_16_wrapper<17, 17>(half_ina, half_inb, half_out);
     fmult_32_wrapper<17, 17>(float_ina, float_inb, float_out);
     fmult_64_wrapper<17, 17>(double_ina, double_inb, double_out);

--- a/udp_tx/udp_tx.cpp
+++ b/udp_tx/udp_tx.cpp
@@ -265,6 +265,7 @@ void udpTxChecksum(hls::FIFO<AxiWord> &data_in,
 void udpTx(hls::FIFO<AxiWord> &data_in, hls::FIFO<metadata> &metadata_in,
            hls::FIFO<ap_uint<16>> &length_in, hls::FIFO<AxiWord> &data_out) {
 #pragma HLS function top
+#pragma HLS function dataflow
 
     // Declare intermediate hls::FIFOs for inter-function communication
     // Note that the FIFO size should be big enough to hold the whole packet


### PR DESCRIPTION
Description:
Prior to dataflow, when using function pipelines, SmartHLS did not support non-FIFO arguments to a sequence of function pipelines unless the non-FIFO argument was only used by the first function of the sequence. To work around this SmartHLS limitation in Training 1, we added the switch input as a FIFO that is always valid. This removes that hack which might have been confusing for the user. It also prevents all the dataflow functions being root functions.

Testing:
* Passes cosim
* Regenerated the training and tested that it works on the board
* Took the 2022.2 Libero zip project and replaced the canny_top component, still works on the board