### PR TITLE
Set dialect to C++11

### DIFF
--- a/Training1/Canny/.cproject
+++ b/Training1/Canny/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.376673803" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.1759095256" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.1810804837" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1733918208" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.994173059" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/Training1/Canny_FIFO_Switch/.cproject
+++ b/Training1/Canny_FIFO_Switch/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.376673803" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.1759095256" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.1810804837" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1733918208" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.994173059" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/Training1/Gaussian_FIFO_Pipelined/.cproject
+++ b/Training1/Gaussian_FIFO_Pipelined/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.376673803" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.1759095256" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.1810804837" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1733918208" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.994173059" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/Training1/Gaussian_Memory_Interface/.cproject
+++ b/Training1/Gaussian_Memory_Interface/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.376673803" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.1759095256" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.1810804837" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1733918208" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.994173059" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/Training1/Gaussian_Memory_Interface_Pipelined/.cproject
+++ b/Training1/Gaussian_Memory_Interface_Pipelined/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.376673803" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.1759095256" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.1810804837" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1733918208" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.994173059" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/Training1/RGB2YCbCr/.cproject
+++ b/Training1/RGB2YCbCr/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.376673803" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.1759095256" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.1810804837" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1733918208" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.994173059" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/Training1/YCbCr2RGB/.cproject
+++ b/Training1/YCbCr2RGB/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.376673803" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.1759095256" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.1810804837" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1733918208" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.994173059" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/Training1/alpha_blend/.cproject
+++ b/Training1/alpha_blend/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.376673803" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.1759095256" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.1810804837" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1733918208" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.994173059" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/Training1/pipeline_hazards/.cproject
+++ b/Training1/pipeline_hazards/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.1129551615" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.2042635163" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.1787542767" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1028178645" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.633098304" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/Training3/texture_mapper/.cproject
+++ b/Training3/texture_mapper/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.814200967" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.1619533930" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.577211025" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.228705348" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.1664402991" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/Training3/wide_mult_axi/.cproject
+++ b/Training3/wide_mult_axi/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.814200967" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.1619533930" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.577211025" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.228705348" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.1664402991" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/Training3/wide_mult_axi_target/.cproject
+++ b/Training3/wide_mult_axi_target/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.814200967" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.1619533930" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.577211025" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.228705348" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.1664402991" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/Training3/wide_mult_axi_target_template/.cproject
+++ b/Training3/wide_mult_axi_target_template/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.814200967" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.1619533930" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.577211025" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.228705348" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.1664402991" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">

--- a/axi_initiator/.cproject
+++ b/axi_initiator/.cproject
@@ -21,6 +21,7 @@
 							<tool id="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug.1073813088" name="GCC C++ Compiler" superClass="legup.managedbuild.tool.gnu.cpp.compiler.exe.debug">
 								<option id="gnu.cpp.compiler.option.optimization.level.833907967" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.most" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.debugging.level.180824864" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.dialect.std.2033344015" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++11" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.592007040" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="legup.managedbuild.tool.gnu.c.compiler.exe.debug.1734828794" name="GCC C Compiler" superClass="legup.managedbuild.tool.gnu.c.compiler.exe.debug">


### PR DESCRIPTION
For projects that did not specify C+11 as the dialect, std library classes and types could be shown as error with a red underline.