### PR TITLE
Fix testbench of wide_mult in Training3

### DIFF
--- a/Training3/wide_mult/WideMultTopPf_Tb.sv
+++ b/Training3/wide_mult/WideMultTopPf_Tb.sv
@@ -297,6 +297,7 @@ integer num_res = 0;
 integer num_mismatch = 0;
 
 always @ (result) begin
+    @(negedge SYSCLK)
     $display ("time=%0t num=%d\n  A=%h B=%h C=%h D=%h E=%h\n  result=               %h\n  check_result_widemult=%h",
              $time, num_res, astim_r_delayed, bstim_r_delayed, cstim_r_delayed,
              dstim_r_delayed, estim_r_delayed, result, check_result_widemult,);


### PR DESCRIPTION
In the last `always` block of `WideMultTopPf_Tb.sv`, output result comparison is performed when `result `changes, and the golden value for comparison, `check_result_widemult`, is arranged to be generated at the same time in the testbench. In some simulation mode of ModelSim, we encountered a situation that value change of both `result `and `check_result_widemult` are found happening at the same time, but `check_result_widemult `still holds the old value when simulation execution control goes into the `always @(result)` block. To avoid this simulation implementation issue affects the correctness of this testbench, an extra statement, `@(negedge SYSCLK)` is added in the beginning of the `always @(result)` block body, to delay result checking to the next negedge clock to make sure `check_result_widemult` is also settled.