### PR TITLE
Update User Guide Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The homepage for the Microchip HLS integrated development environment is:
  - https://www.microchip.com/en-us/products/fpgas-and-plds/fpga-and-soc-design-tools/smarthls-compiler
 
 You can find the Microchip HLS software user guide here:
- - https://microchiptech.github.io/fpga-hls-docs/
+ - https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=fpgahls&redirect=true&version=latest 
 
 ## Tutorials and Trainings
 Example | Description

--- a/Training1/readme.md
+++ b/Training1/readme.md
@@ -2010,7 +2010,7 @@ to the nearest integer.
 For this computation we are using a 18-bit fixed-point type with 10
 integer bits and 8 fractional bits (Q10.8) as defined below using the
 `ap_fixpt` SmartHLS arbitrary precision fixed-point data type (see
-[SmartHLS documentation](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-61CF52C5-A40E-436D-9E38-AD885C0EF16D.html)):
+[SmartHLS documentation](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_fixed_point&redirect=true&version=latest)):
 ```c
 typedef ap_fixpt<18, 10> fixpt_t;
 ```
@@ -2311,7 +2311,7 @@ rgb.G = ap_ufixpt<8, 8, AP_TRN, AP_SAT>(G);
 rgb.B = ap_ufixpt<8, 8, AP_TRN, AP_SAT>(B);
 ```
 From the SmartHLS [user
-guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-61CF52C5-A40E-436D-9E38-AD885C0EF16D.html),
+guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_arbitary_precision&redirect=true&version=latest),
 the `AP_SAT` option means that on positive and negative overflow,
 saturate the result to the maximum or minimum value in the range
 respectively.
@@ -3246,7 +3246,8 @@ dataflow pragma causes the four sub-functions to overlap their execution
 and is ideal for generating a design where multiple functions are
 connected to operate as a single pipeline. To learn more about the
 dataflow pragma, see the [SmartHLS
-Documentation](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-24B4CBDB-506F-433E-95F9-28FA2811E9CF.html).
+Documentation](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_data_flow&redirect=true&version=latest
+).
 ```c
 void canny(hls::FIFO<unsigned char> &input_fifo,
            hls::FIFO<unsigned char> &output_fifo) {

--- a/Training2/readme.md
+++ b/Training2/readme.md
@@ -238,7 +238,7 @@ synthesis.
 
 When designing a hardware block using SmartHLS, parallelism is the main
 way of achieving performance gain. As mentioned in the [SmartHLS user
-guide](https://microchiptech.github.io/fpga-hls-docs/userguide.html#introduction-to-high-level-synthesis),
+guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=fpgahls&redirect=true&version=latest),
 there are four main kinds of parallelism in SmartHLS: instruction-level,
 loop-level, thread-level, and dataflow parallelism. These concepts have
 some overlap between them, but they all focus on running as many tasks
@@ -389,7 +389,7 @@ parallel on a data stream. It allows tasks to start executing as soon as
 their prerequisites are ready. Dataflow parallelism was shown in
 Training 1, and more detailed information can be found in the [SmartHLS
 User
-Guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-24B4CBDB-506F-433E-95F9-28FA2811E9CF.html).
+Guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_data_flow&redirect=true&version=latest).
 An example using dataflow parallelism will also be discussed in Appendix
 D. For more complex parallelism, e.g., with feedback/cycles between the
 parallel tasks, multi-threading APIs may be needed to explicitly
@@ -420,7 +420,7 @@ Goals of this section:
 Creating parallel modules using threads is easy in SmartHLS. SmartHLS
 comes with a threading library with a simple API for creating threads.
 Detailed information on this API can be found in the [SmartHLS User
-Guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-E3BCA8C1-1F5A-41C2-B0A6-F33C48F33FA7.html).
+Guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_multi_threading&redirect=true&version=latest).
 SmartHLS previously supported POSIX threads (pthreads) but the pthreads
 API was deprecated in SmartHLS 2022.3 and the SmartHLS thread API is now
 the recommended way to create threads. Here we will present the basics
@@ -512,7 +512,7 @@ contention free to be able to show what the generated arbiter looks like
 in RTL. Note, the contention free pragma must precede the variable
 declaration unlike pragmas such as the function top pragma. For more
 information on where pragmas need to be defined, check the 
-[SmartHLS Pragmas Manual](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-B3D89018-0850-487C-A242-A433094D720F.html).
+[SmartHLS Pragmas Manual](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_pragmas&redirect=true&version=latest).
 
 ![](.//media/image3.png) To check for generated arbiters, compile the
 design to hardware (![](.//media/image28.png)) and open the generated
@@ -718,7 +718,7 @@ in software, the same functionality is replicated by SmartHLS in
 hardware.
 
 A generic example on how to use the mutex can be found in the [User
-Guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-AEB83DF1-3E37-4FE5-B386-E2BEBCF7E15E.html),
+Guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_thread_apis&redirect=true&version=latest),
 where a global mutex is locked and unlocked to ensure that the function
 body runs atomically.
 
@@ -754,7 +754,7 @@ before the other threads are ready. A barrier can handle any number of
 threads but must be given the number during creation.
 
 A generic example on how to use the barrier can be found in the [User
-Guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-AEB83DF1-3E37-4FE5-B386-E2BEBCF7E15E.html),
+Guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_thread_apis&redirect=true&version=latest),
 where a global barrier is initiated in main for the two threads that
 will use it. Inside the threaded function, a call to wait is made to
 block the thread until the two threads reach the barrier.

--- a/Training3/readme.md
+++ b/Training3/readme.md
@@ -54,7 +54,7 @@ Updated document for SmartHLS™ 2024.1 release.
         generate an arithmetic hardware block with a wide datapath and
         compare to an RTL reference design.
       - Referring to previous SmartHLS trainings.
-      - Referring to the [SmartHLS User Guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-995D69CF-ACC7-4CB0-9635-4434A765470E.html).
+      - Referring to the [SmartHLS User Guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=fpgahls&redirect=true&version=latest).
       - Referring to the [SmartHLS Github examples repository](https://github.com/MicrochipTech/fpga-hls-examples).
   - AXI protocol and SmartHLS:
       - SmartHLS AXI target (also called AXI subordinate or slave)
@@ -132,11 +132,11 @@ The following hardware is required:
     ([MPF300-VIDEO-KIT](https://www.microsemi.com/existing-parts/parts/150747)).
   - Monitor with an HDMI input.
 
-In the [SmartHLS user guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-995D69CF-ACC7-4CB0-9635-4434A765470E.html),
-you should read [Section 'SmartHLS C/C++ Library'](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-11FC7907-490C-47AB-9DAC-2B20334691D4.html)
-up to and including [Section 'Supported Operations in ap\_\[u\]int/ap\_\[u\]fixpt, and floating-point'](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-530A2A58-DEC9-4AAA-9DDC-E07BA18EF9E0.html),
+In the [SmartHLS user guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=fpgahls&redirect=true&version=latest),
+you should read [Section 'SmartHLS C/C++ Library'](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_c_library&redirect=true&version=latest)
+up to and including [Section 'Supported Operations in ap\_\[u\]int/ap\_\[u\]fixpt, and floating-point'](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_supported_operations&redirect=true&version=latest),
 and [Section 'AXI4 Target
-Interface'](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-16F30D96-8744-48F6-BD42-AC01ED5460ED.html).
+Interface'](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_axi4_target&redirect=true&version=latest).
 This knowledge will be directly applied in this training.
 
 We assume some knowledge of the C/C++ programming language for this
@@ -357,19 +357,19 @@ Figure 3: Adding custom SystemVerilog testbench.</p>
 Many methods and libraries used in previous trainings can be applied in
 creating this wide multiply block. Some topics include the C++ arbitrary
 precision library, how top-level function interfaces map to hardware,
-and pipelining. Refer to the [SmartHLS User Guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-995D69CF-ACC7-4CB0-9635-4434A765470E.html)
+and pipelining. Refer to the [SmartHLS User Guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=fpgahls&redirect=true&version=latest)
 or [previous trainings](https://microchiptechnology.sharepoint.com/sites/InfoDepot/FPGA_SOC%20LegUp%20Site/SitePages/FAE-Training-Slides-and-Video.aspx)
 for more details on specific topics.
 
 All of the necessary operators to implement the wide multiply operations
-are provided in the arbitrary precision library API. Read [Section 'C++ Arbitrary Precision Data Types Library'](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-EA20C103-EBF1-4FEC-9D7C-096162AB657C.html)
+are provided in the arbitrary precision library API. Read [Section 'C++ Arbitrary Precision Data Types Library'](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_data_types&redirect=true&version=latest)
 in the SmartHLS User Guide if you have not already. This section
 provides information about the arbitrary precision library. Keep in mind
 that the operation performed in the divide-by-two operation in the
 original RTL is implemented as an arithmetic right shift-by-one. The
 “\>\>” operator in C++ is a logical right shift and not an arithmetic
 right shift. You must use an arithmetic right shift operation to handle
-signed division properly. See: [Section 'Supported Operations in ap\_\[u\]int/ap\_\[u\]fixpt, and floating-point'](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-530A2A58-DEC9-4AAA-9DDC-E07BA18EF9E0.html).
+signed division properly. See: [Section 'Supported Operations in ap\_\[u\]int/ap\_\[u\]fixpt, and floating-point'](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_supported_operations&redirect=true&version=latest).
 
 When you use the SmartHLS C++ arbitrary precision library, SmartHLS
 automatically handles sign extension, padding, and shifting when
@@ -599,7 +599,7 @@ in most FPGA use cases.
 ![](.//media/image3.png)In this section, we want you to implement an AXI
 target interface in SmartHLS to communicate with the Mi-V processor.
 
-To start, you should see [Section 'AXI4 Target Interface'](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-16F30D96-8744-48F6-BD42-AC01ED5460ED.html)
+To start, you should see [Section 'AXI4 Target Interface'](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_axi4_target&redirect=true&version=latest)
 in the SmartHLS User Guide if you haven’t already. This section includes
 information on how to create a AXI target interface in SmartHLS. You can
 also start with an example found in the SmartHLS Github [examples repository](https://github.com/MicrochipTech/fpga-hls-examples). Note,
@@ -616,7 +616,7 @@ Note, SmartHLS does not support using C++ arbitrary precision types
 inside of an AXI4 target struct. However, C++ arbitrary precision types
 should still be used for the wide multiply computations. This can be
 achieved by assigning the simple types in the target struct to the
-corresponding slices of the arbitrary precision type. See: [Section 'Selecting and Assigning to a Range of Bits'](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-21FDCBD6-626A-4D3A-AFE3-4A88952293C7.html).
+corresponding slices of the arbitrary precision type. See: [Section 'Selecting and Assigning to a Range of Bits'](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_selecting_assigning&redirect=true&version=latest).
 
 Next you will find the *initiator\_layout.txt* file in the template
 project. This gives you the processor side memory map layout for
@@ -1288,7 +1288,7 @@ blocks as delay elements to line up the inputs to the pipeline stages
 where they are used. These were implemented with uSRAM FIFOs. SmartHLS
 2022.3 also uses uSRAM FIFOs for pipeline registers. If you are using an
 older version of SmartHLS, you can set the
-[USE\_FIFO\_FOR\_PIPELINE\_REG](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-EE7D70B4-A250-4503-AFAC-056F88433277.html)
+[USE\_FIFO\_FOR\_PIPELINE\_REG](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_use_fifo_for_pipieline_reg&redirect=true&version=latest)
 parameter to 1 in a custom configuration file to enable this behavior.
 The steps to do this are similar to setting the `STRENGTH_REDUCTION`
 parameter as seen in the RGB2YCbCr section of the [SmartHLS Training 1 document](https://github.com/MicrochipTech/fpga-hls-examples/tree/main/Training1/).

--- a/Training4/readme.md
+++ b/Training4/readme.md
@@ -85,9 +85,9 @@ Interface](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_axi4_i
 [AXI4 Target
 Interface](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_axi4_target&redirect=true&version=latest),
 [Driver Functions for AXI4
-Target](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-7BBF0DBC-AA2A-4593-9B3F-65EDD8520ACE.html),
+Target](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-12/GUID-7BBF0DBC-AA2A-4593-9B3F-65EDD8520ACE.html),
 and [User-defined
-SmartDesigns](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-8CD9C2D1-7FF3-4C70-8CB7-364597AFDAD7.html).
+SmartDesigns](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-12/GUID-8CD9C2D1-7FF3-4C70-8CB7-364597AFDAD7.html).
 
 
 ![](.//media/image3.png) We will use this cursor symbol throughout this tutorial to indicate sections where you need to perform actions to follow along.
@@ -755,7 +755,7 @@ file implements the driver functions. The driver functions are generated
 for arguments and module control if they are configured to use AXI4
 target interface. Figure 6‑22 summarizes the different categories of
 driver functions. Please visit [Driver Functions for AXI4
-Target](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-7BBF0DBC-AA2A-4593-9B3F-65EDD8520ACE.html)
+Target](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-12/GUID-7BBF0DBC-AA2A-4593-9B3F-65EDD8520ACE.html)
 section of our user guide for a more detailed explanation.
 
 <table>
@@ -1112,7 +1112,7 @@ data transfers between the DDR and the accelerator. Any additional
 accelerators would be connected to the same AXI interconnect. For more
 information on the architecture of the Reference SoC, please see our
 [user
-guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-0B124EE7-BB34-4CF3-A591-9658F121B533.html).
+guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-12/GUID-0B124EE7-BB34-4CF3-A591-9658F121B533.html).
 
 We can simplify the SmartDesign visualization by clicking
 ![](.//media/image38.png)Hide Nets, ![](.//media/image39.png)Compress
@@ -1357,7 +1357,7 @@ Figure 6‑42.
 DMA Copy mode and Accelerator Direct Access require the memory to be
 allocated using the `hls_malloc` function from the [SmartHLS Memory
 Allocation
-Library](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-8246D542-5D26-420C-9418-6D798FDFC215.html)
+Library](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-12/GUID-8246D542-5D26-420C-9418-6D798FDFC215.html)
 to keep data in physically contiguous memory for the DMA engine. Using
 `hls_malloc` prevents splitting data across different virtual memory
 pages in physical memory. The accelerators and DMA engine do not perform
@@ -1412,7 +1412,7 @@ SmartHLS reads in `Makefile.user` where users can define and modify
 options such as compiler and linker flags. For example, users can modify
 `USER_CXX_FLAG` to append additional C++ compilation flags for their
 project. Visit the [Makefile
-Variable](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-398C5B20-F31F-4C97-AA81-DDDC0BE0F469.html)
+Variable](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-12/GUID-398C5B20-F31F-4C97-AA81-DDDC0BE0F469.html)
 section of our user guide for a full list of predefined user flags and
 their uses.
 
@@ -2204,7 +2204,7 @@ SoC, we already have [programmed our Custom SoC bitstream to the FPGA](#programm
 `Makefile.user` defines various options related to compiling and running
 the compiled program. Figure 8‑26 is a snippet of `Makefile.user`
 containing the runtime settings. Visit the [Makefile
-Variable](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-398C5B20-F31F-4C97-AA81-DDDC0BE0F469.html)
+Variable](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-12/GUID-398C5B20-F31F-4C97-AA81-DDDC0BE0F469.html)
 section of our user guide for a full list of predefined user flags and
 their uses. Important: Ensure that `SRCS` is set to
 `main_variables/main.simple.cpp`.
@@ -2397,7 +2397,7 @@ Running with hardware module, the CPU utilization is about 11%:
 <p align="center">Figure 8‑33 CPU Usage when Running with Accelerators</p></p>
 
 SmartHLS has a TCL parameter called
-[SOC\_POLL\_DELAY](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-8CD9C2D1-7FF3-4C70-8CB7-364597AFDAD7.html)
+[SOC\_POLL\_DELAY](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-12/GUID-8CD9C2D1-7FF3-4C70-8CB7-364597AFDAD7.html)
 with a value specified in microseconds. This parameter is used for
 controlling how often the hardware driver polls the module to check for
 completion. Sometimes for long running tasks, the MSS only needs to
@@ -2449,7 +2449,7 @@ different call in main.non-blocking.cpp as shown in Figure 8‑34.
 ```
 <p align="center">Figure 8‑34 Main Execution Loop of main.non-blocking.cpp</p>
 
-[HAS\_ACCELERATOR](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-6818975C-389F-427C-B913-65A667001A99.html#GUID-6818975C-389F-427C-B913-65A667001A99__SECTION_YMS_QTJ_NYB)
+[HAS\_ACCELERATOR](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-12/GUID-6818975C-389F-427C-B913-65A667001A99.html#GUID-6818975C-389F-427C-B913-65A667001A99__SECTION_YMS_QTJ_NYB)
 is a SmartHLS defined macro that indicates whether the program is
 compiled with accelerators or not. The `*_write_input_and_start()`
 functions send the data to the hardware accelerator and start the
@@ -2546,7 +2546,7 @@ function is a classic example of the producer-consumer pattern. The in
 data is received from the AXI target interface and passed to each stage
 of the computation, namely `invert` and `threshold_to_zero`. We use a
 thread
-([hls::thread](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-D3311A34-24FB-4A0D-8A49-A0A56F71410F.html))
+([hls::thread](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-12/GUID-D3311A34-24FB-4A0D-8A49-A0A56F71410F.html))
 for each stage as each stage can be run independently as long as there
 are data available. The two stages are connected via a fifo between
 them.

--- a/Training4/readme.md
+++ b/Training4/readme.md
@@ -78,12 +78,12 @@ Later parts of the training involve running steps on the Icicle kit board. The f
   - Either a FlashPro6 external programmer or a micro-USB cable for the embedded FlashPro6
   - Ethernet cable for network connection to the board for SSH access
 
-This training will cover the following sections in the [SmartHLS user guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-995D69CF-ACC7-4CB0-9635-4434A765470E.html): [SoC
-Features](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-7324A022-0DE8-45E9-9FF0-E06D6CC7AD40.html),
+This training will cover the following sections in the [SmartHLS user guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=fpgahls&redirect=true&version=latest): [SoC
+Features](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_soc_features&redirect=true&version=latest),
 [AXI4 Initiator
-Interface](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-93A05651-C06B-4805-94D3-0443DC0FED4E.html),
-[AXI4Target
-Interface](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-16F30D96-8744-48F6-BD42-AC01ED5460ED.html),
+Interface](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_axi4_initiator&redirect=true&version=latest),
+[AXI4 Target
+Interface](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_axi4_target&redirect=true&version=latest),
 [Driver Functions for AXI4
 Target](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-7BBF0DBC-AA2A-4593-9B3F-65EDD8520ACE.html),
 and [User-defined
@@ -299,7 +299,7 @@ flow on the C++ (compile/run/debug). Then we apply HLS constraints using
 SmartHLS C++ pragmas. These include HLS constraints covered in previous
 trainings such as the target clock period, loop optimizations, and
 memory configuration. For more details see our [optimization
-guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-8B9C18AF-E1F4-400A-A369-2668F3632CF5.html).
+guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_optimization_ug&redirect=true&version=latest).
 
 There are new SmartHLS **interface** pragmas used to specify the data
 transfer method for each top-level function argument. These pragmas
@@ -308,7 +308,7 @@ of the SoC. Figure 6‑10 below contains a summary of the SmartHLS pragmas
 used in the vector-add example. More details on the interfaces will be
 covered in the [SoC Data Transfer Methods](#soc-data-transfer-methods) section. For a complete pragma reference, see our
 [pragma
-guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-B3D89018-0850-487C-A242-A433094D720F.html).
+guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_data_transfer&redirect=true&version=latest).
 
 In Figure 6‑9, after specifying the argument interfaces, we can compile
 the software into a hardware IP core using SmartHLS, and review reports
@@ -432,7 +432,7 @@ accelerator will store the data in local memory blocks. The
 `num_elements` field specifies the length of the array that will be
 transferred for each argument. For more information on the required
 pragmas and tradeoffs, please see our [pragma
-manual](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-37FB7C46-32B5-4CAF-8CA2-3B7F37B7E7B9.html).
+manual](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_pragmas&redirect=true&version=latest).
 
 In this example, we separated the core C++ algorithm into the
 `vector_add_sw` function. We can then call this function from multiple
@@ -529,7 +529,7 @@ by both the software testbench and hardware functions. I/O memories
 become memory interfaces of the top-level module for the generated
 hardware. For more information on interfaces, please refer to [Top-Level
 RTL
-Interface](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-E9EA34CC-B155-4F12-AFFC-B972E037469F.html).
+Interface](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_toplevel_rtl&redirect=true&version=latest).
 
 The “I/O Memories” table is shown in Figure 6‑15 and has an entry for
 each top-level function argument, which each have a data width of
@@ -1145,7 +1145,7 @@ to accelerator’s on-chip memory buffer, or the data can be accessed
 directly in DDR by the accelerator. Any access to DDR, whether data is
 copied or accessed directly, goes through the MSS data cache to maintain
 cache coherency. See the [SoC Data Transfer
-Methods](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-212067DF-C1B6-4C22-ADDD-3C306CE990E5.html)
+Methods](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_data_transfer&redirect=true&version=latest)
 user guide section for further reference.
 
 #### CPU Copy: AXI Target
@@ -1267,7 +1267,7 @@ the data for argument "`a`" with the AXI initiator interface as shown in
 Figure 6‑37. If the `ptr_addr_interface` is not specified, for example
 for argument b, SmartHLS will use the default interface type defined on
 line 123 (`axi_target`). See the [AXI4 Initiator
-Interface](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-93A05651-C06B-4805-94D3-0443DC0FED4E.html)
+Interface](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_axi4_initiator&redirect=true&version=latest)
 section of the user guide.
 
 If users specify the `ptr_addr_interface` or any other interface type as
@@ -1388,7 +1388,7 @@ SoC reference project is generated.
 
 ![](.//media/image3.png) To prepare your Icicle kit for use with
 SmartHLS, follow the [Icicle Setup
-Instructions](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-1F9BA312-87A9-43F0-A66E-B83D805E3F02.html)
+Instructions](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_iciclekit&redirect=true&version=latest)
 and note down the IP of the board.
 
 ![](.//media/image3.png)Create a new file named `Makefile.user` by right
@@ -1622,7 +1622,7 @@ set_parameter SOC_CPU_MEM_SIZE            0x60000000
 <p align="center">Figure 8‑3 Default Parameter Values for Integrating SmartHLS</p>
 
 Users can change the default parameters by [creating a
-*custom\_config.tcl*](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-3636C6BE-3977-4267-A5DF-A514D1A46BE3.html)
+*custom\_config.tcl*](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_constraints&redirect=true&version=latest)
 file inside their HLS project. For example, if we wanted to change the
 `SOC_FABRIC_BASE_ADDRESS` to start at `0x70100000`, we would include the
 following in our *custom\_config.tcl* file:
@@ -1723,7 +1723,7 @@ As in the [Vector Add On-Board section](#running-vector-add-reference-soc-genera
 a Linux image needs to be flashed to the eMMC memory in
 the Icicle board. If users have already flashed the Linux image as
 described in the [Icicle Setup
-Guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-1F9BA312-87A9-43F0-A66E-B83D805E3F02.html),
+Guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_iciclekit&redirect=true&version=latest),
 this section may be skipped, and users may move on to [this section](#extract-the-icicle-kit-reference-design-files). A
 similar procedure can be followed for the user’s own Linux image when
 integrating SmartHLS design into their own existing system.
@@ -1736,7 +1736,7 @@ from [PolarFire SoC Yocto BSP
 .
 
 ![](.//media/image3.png)Follow the instructions on [Icicle Setup
-Guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-1F9BA312-87A9-43F0-A66E-B83D805E3F02.html)
+Guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_iciclekit&redirect=true&version=latest)
 for setting the Icicle kit. As explained in the guide, when flashing the
 Icicle board (Step 5 in the Icicle Setup Guide), use
 `core-image-minimal-dev-icicle-kit-es.wic.gz` that you have downloaded in
@@ -2028,7 +2028,7 @@ the newly added Linux image.
 
 ![](.//media/image3.png) After the board has successfully booted, you
 can connect using a serial terminal. Connect in the same
-[manner](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-88244281-BA99-4B1D-9E38-43EE07745978.html)
+[manner](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_iciclekit&redirect=true&version=latest)
 as the serial terminal used during the writing of the Linux image,
 except this time using channel 1 (`/dev/ttyUSB1`on Linux,
 and `Interface 1` on Windows), you should see a login screen:

--- a/axi_initiator/README.md
+++ b/axi_initiator/README.md
@@ -2,7 +2,7 @@ This is an example project to show you how to create an AXI4-Initiator top-level
 
 Please follow the user guide to install SmartHLS and learn more about the features of this HLS tool:
  - Homepage: https://www.microchip.com/en-us/products/fpgas-and-plds/fpga-and-soc-design-tools/smarthls-compiler
- - User guide: https://microchiptech.github.io/fpga-hls-docs/
+ - User guide: https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=fpgahls&redirect=true&version=latest
 
 After the installation is done, you can try out this example through either GUI or command-line. 
 

--- a/axi_target/README.md
+++ b/axi_target/README.md
@@ -2,7 +2,7 @@ This is an example project to show you how to create an AXI4-Target top-level in
 
 Please follow the user guide to install SmartHLS and learn more about the features of this HLS tool:
  - Homepage: https://www.microchip.com/en-us/products/fpgas-and-plds/fpga-and-soc-design-tools/smarthls-compiler
- - User guide: https://microchiptech.github.io/fpga-hls-docs/
+ - User guide: https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=fpgahls&redirect=true&version=latest
 
 After the installation is done, you can try out this example through either GUI or command-line. 
 

--- a/fp_mult/README.md
+++ b/fp_mult/README.md
@@ -16,7 +16,7 @@ format, implemented by the third party library in half.hpp.
 
 Please follow the user guide to install SmartHLS and learn more about the features of this HLS tool:
  - Homepage: https://www.microchip.com/en-us/products/fpgas-and-plds/fpga-and-soc-design-tools/smarthls-compiler
- - User guide: https://microchiptech.github.io/fpga-hls-docs/
+ - User guide: https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=fpgahls&redirect=true&version=latest 
 
 After the installation is done, you can try out this example through either GUI
 or command-line. 

--- a/risc-v-demo/Readme-compile.md
+++ b/risc-v-demo/Readme-compile.md
@@ -347,7 +347,7 @@ Finally, the `common` directory has some common bitmaps and helper code.
 
 ## References:
 
-[SmartHLS User Guide](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-995D69CF-ACC7-4CB0-9635-4434A765470E.html)
+[SmartHLS User Guide](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=fpgahls&redirect=true&version=latest)
 
 [PolarFire_SoC_FPGA_H264_Video_Streaming_Over_Ethernet_Application_Note_AN4529.pdf](https://ww1.microchip.com/downloads/aemDocuments/documents/FPGA/ApplicationNotes/ApplicationNotes/PolarFire_SoC_FPGA_H264_Video_Streaming_Over_Ethernet_Application_Note_AN4529.pdf)
 

--- a/risc-v-demo/Readme.md
+++ b/risc-v-demo/Readme.md
@@ -295,7 +295,7 @@ now updated.
 
 **NOTE:** 
 As an additional reference about terminals and the image flashing process,
-you can check the [IcicleKit Setup Instructions](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-11/GUID-1F9BA312-87A9-43F0-A66E-B83D805E3F02.html). 
+you can check the [IcicleKit Setup Instructions](https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=hls_iciclekit&redirect=true&version=latest). 
 It includes instructions and additional screen captures for the PolarFire Icicle 
 kit but the the process is similar in the PolarFire SoC Video Kit, except they 
 use different image files.

--- a/sobel_tutorial/README.md
+++ b/sobel_tutorial/README.md
@@ -7,4 +7,4 @@ how to implement and optimize a simple image processing design using SmartHLS.
 
 Please follow the user guide to install SmartHLS and learn more about the features of this HLS tool:
  - Homepage: https://www.microchip.com/en-us/products/fpgas-and-plds/fpga-and-soc-design-tools/smarthls-compiler
- - User guide: https://microchiptech.github.io/fpga-hls-docs/
+ - User guide: https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=fpgahls&redirect=true&version=latest

--- a/udp_tx/README.md
+++ b/udp_tx/README.md
@@ -2,7 +2,7 @@ This is an example source code to show how to write an IP block to implement UDP
 
 Please follow the user guide to install SmartHLS and learn more about the features of this HLS tool:
  - Homepage: https://www.microchip.com/en-us/products/fpgas-and-plds/fpga-and-soc-design-tools/smarthls-compiler
- - User guide: https://microchiptech.github.io/fpga-hls-docs/
+ - User guide: https://onlinedocs.microchip.com/v2/keyword-lookup?keyword=fpgahls&redirect=true&version=latest 
 
 After the installation is done, you can try out this example through either GUI or command-line. 
 


### PR DESCRIPTION
Updated the User Guide links in the examples to point to the permalinks (instead of the GUID versions) for topics that _have_ permanent links. 

For topics that do not have a permanent link, I updated the links from version 11 (now broken, but worked at time of release) to version 12 (work now.)
