### PR TITLE
Added fix for getting the base_path when using a release version of SHLS

### DIFF
--- a/risc-v-demo/sev-kit-reference-design/script_support/additional_configurations/functions.tcl
+++ b/risc-v-demo/sev-kit-reference-design/script_support/additional_configurations/functions.tcl
@@ -21,16 +21,16 @@ proc getHlsPaths { } {
     } else {
         global shls_path
         if { $OS == "Linux" } {
-            set base_path [string cat [string trimright $install_loc Libero]/SmartHLS-$liberoRelease {/}]
-            set ::env(PATH) [string cat $::env(PATH) ":" $base_path {SmartHLS/bin}]
-            set shls_path [string cat $base_path {SmartHLS/bin/shls}]
+            set base_path [string cat [string trimright $install_loc Libero]/SmartHLS-$liberoRelease {/SmartHLS}]
+            set ::env(PATH) [string cat $::env(PATH) ":" $base_path {/bin}]
+            set shls_path [string cat $base_path {/bin/shls}]
         } else {
-            set base_path [string cat [string trimright $install_loc Designer]SmartHLS-$liberoRelease {/}]
+            set base_path [string cat [string trimright $install_loc Designer]SmartHLS-$liberoRelease {/SmartHLS}]
             set base_path [file normalize $base_path]
             set drive [string range $install_loc 0 0]
-            set shls_path "$base_path/SmartHLS/bin/shls.bat"
+            set shls_path "$base_path/bin/shls.bat"
             set shls_path [file normalize $shls_path]
-            set ::env(PATH) [string cat $::env(PATH) ";" $base_path {SmartHLS/bin}]
+            set ::env(PATH) [string cat $::env(PATH) ";" $base_path {bin}]
         }
     }
     puts "base_path: $base_path"


### PR DESCRIPTION
This fix doesn't work if the "shls" env var isn't in the path (line 21). The change to
`risc-v-demo/sev-kit-reference-design/script_support/additional_configurations/smarthls/sd_add_axis_converters.tcl`
means that "base_path" needs to be one level up from `bin`. So then that means "base_path" should be `Libero_SoC_v2024.1/SmartHLS-2024.1/SmartHLS` or  `C:\Microchip\Libero_SoC_v2024.1\SmartHLS-2024.1\SmartHLS`. 

Also note that the "shls_path" for a Windows user will always be the version of SHLS included with their Libero release, since the "which" command doesn't exist in cmd-- the equivalent is "where" (line 17).  The fix would be something like:
```C   
if { $OS == "Linux" } {
   if {![info exists shls_path]} {catch {set shls_path [exec which shls]}}
   if {[info exists shls_path]} {
        set base_path [string trimright $shls_path bin/shls]
    }
} else {
   if {![info exists shls_path]} {catch {set shls_path [exec which shls]}}
   if {[info exists shls_path]} {
        set base_path [string trimright $shls_path bin\\shls.bat]
    }
}
```
I don't know when anyone would want to do this, other than maybe testing a Windows development version of SHLS