### PR TITLE
Typos

### DIFF
--- a/Training1/readme.md
+++ b/Training1/readme.md
@@ -1742,7 +1742,7 @@ is presented in Figure 20.
 void functional_unit_contention( volatile int array[N] ) {
 #pragma HLS loop unroll factor(1)
 #pragma HLS loop pipeline
-    for (int I = 0; i < N; i++) {
+    for (int i = 0; i < N; i++) {
         int mult1 = coeff1 * coeff1;
         int mult2 = coeff2 * coeff2;
         array[i] = mult1 + mult2;

--- a/Training2/readme.md
+++ b/Training2/readme.md
@@ -300,7 +300,7 @@ parallel. SmartHLS leverages loop-level parallelism when pipelining a
 loop to allow multiple loop iterations to execute in parallel.
 Pipelining is a common hardware optimization to increase the throughput
 of a circuit that repeatedly processes data in a series of steps and
-achieve higher hardware utilization. We have already seen this kind of
+achieves higher hardware utilization. We have already seen this kind of
 parallelism in the Sobel Filter tutorial as well as in the previous
 training on the Canny Edge Detection Filter.
 


### PR DESCRIPTION
Previously, loop was written as 
```c++
for (int I = 0; i < ...
```
This was changed to correct the uppercase loop variable,
```c++
for (int i = 0; i < ...
```