### PR TITLE
set READONLY_RAM_TO_ROM to 0

### DIFF
--- a/Training3/texture_mapper/config.tcl
+++ b/Training3/texture_mapper/config.tcl
@@ -3,3 +3,5 @@
 ########## by using the "Set custom config file" constraint in the HLS Constraints dialog. ##########
 source $env(SHLS_ROOT_DIR)/examples/legup.tcl
 set_project PolarFire MPF300 MiV_SoC
+
+set_parameter READONLY_RAM_TO_ROM 0


### PR DESCRIPTION
Training 3 texture_mapper uses SoftConsole initialized the RAM. Thus, from SmartHLS's point of view, local memories in texture_mapper are read only memories. We add in this new parameter to override the default behavior that generate read-only RAM as ROM.