### PR TITLE
updated risc-v readme and setup script for windows to remove dos line endings

### DIFF
--- a/risc-v-demo/Readme.md
+++ b/risc-v-demo/Readme.md
@@ -149,6 +149,11 @@ your operating system), which copies the libraries from `<SmartHLS INSTALLATION 
 
 - Download the precompiled libraries from the [fpga-hls-libraries](https://github.com/MicrochipTech/fpga-hls-libraries) release assets.
 
+If you are on Windows, depending on your computer's settings you may get this error:
+`\setup.ps1 cannot be loaded because running scripts is disabled on this system.`
+To fix it, open up a new powershell in adminstrator mode, run `Set-ExecutionPolicy Unrestricted`, and close the shell. 
+You can verify that the setting has been changed by running `Get-ExecutionPolicy` in your open shell and checking that it returns `Unrestricted`. 
+You may need to restart your shell for the changes to take effect.
 
 ## Board Setup
 
@@ -369,6 +374,11 @@ If you are using Windows, run:
 cd precompiled
 .\setup.ps1
 ```
+Depending on your computer's settings, you may get this error:
+`\setup.ps1 cannot be loaded because running scripts is disabled on this system.`
+To fix it, open up a new powershell in adminstrator mode, run `Set-ExecutionPolicy Unrestricted`, and close the shell. 
+You can verify that the setting has been changed by running `Get-ExecutionPolicy` in your open shell and checking that it returns `Unrestricted`. 
+You may need to restart your shell for the changes to take effect.
 
 This script will copy the OpenCV and FFMPEG libraries, the files for the control 
 web page, the SmartHLS application executables and some configuration files to 

--- a/risc-v-demo/Readme.md
+++ b/risc-v-demo/Readme.md
@@ -374,11 +374,6 @@ If you are using Windows, run:
 cd precompiled
 .\setup.ps1
 ```
-Depending on your computer's settings, you may get this error:
-`\setup.ps1 cannot be loaded because running scripts is disabled on this system.`
-To fix it, open up a new powershell in adminstrator mode, run `Set-ExecutionPolicy Unrestricted`, and close the shell. 
-You can verify that the setting has been changed by running `Get-ExecutionPolicy` in your open shell and checking that it returns `Unrestricted`. 
-You may need to restart your shell for the changes to take effect.
 
 This script will copy the OpenCV and FFMPEG libraries, the files for the control 
 web page, the SmartHLS application executables and some configuration files to 

--- a/risc-v-demo/precompiled/setup.ps1
+++ b/risc-v-demo/precompiled/setup.ps1
@@ -47,7 +47,6 @@ Invoke-Expression $cmd
 
 # remove dos endings from copied sudoers file
 ssh $SSH_OPT root@$env:BOARD_IP "sed -i 's/\x0D$//' /etc/sudoers.d/0001_daemon"
-ssh $SSH_OPT root@$env:BOARD_IP "sed -i 's/\x0D$//' /srv/www/h264/0001_daemon"
 
 # Copy HLS binaries
 $cmd = "scp $SSH_OPT "

--- a/risc-v-demo/precompiled/setup.ps1
+++ b/risc-v-demo/precompiled/setup.ps1
@@ -45,6 +45,10 @@ $cmd += ":/srv/www/test"
 Write-Host $cmd
 Invoke-Expression $cmd
 
+# remove dos endings from copied sudoers file
+ssh $SSH_OPT root@$env:BOARD_IP "sed -i 's/\x0D$//' /etc/sudoers.d/0001_daemon"
+ssh $SSH_OPT root@$env:BOARD_IP "sed -i 's/\x0D$//' /srv/www/h264/0001_daemon"
+
 # Copy HLS binaries
 $cmd = "scp $SSH_OPT "
 $cmd += "./*.elf "


### PR DESCRIPTION
Updated risc-V demo readme with how to change powershell script execution policy and updated setup.ps1 to remove added dos line endings from 0001_daemon file after it is copied to the linux instance on the board.

Tested on windows laptop with connected Polarfire SOC video kit