### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Example | Description
 [axi_target](./axi_target)|Example of an AXI4-Target top-level interface.
 [Canny_RISCV](./Canny_RISCV)|Integrating a SmartHLS module created using the IP Flow into the RISC-V subsystem.
 [ECC_demo](./ECC_demo)|Example of Error Correction Code feature.
-[auto-instrument](./auto-instrument/)|Example of Automatic On-Chip Instrumentation feature.
+[auto_instrument](./auto_instrument/)|Example of Automatic On-Chip Instrumentation feature.
 
 ## Simple Examples
 Example | Description


### PR DESCRIPTION
Was pointing to the old name `auto-instrument`, rather than `auto_instrument`.