### PR TITLE
Fix typo in auto-instrumentation document

### DIFF
--- a/auto_instrument/README.md
+++ b/auto_instrument/README.md
@@ -537,10 +537,6 @@ Here are some examples of the bar plot. You should confirm these make sense intu
 
 - When the executable is not running on-board, all FIFOs are empty:
 
-  ```console
-  auto_instrument.accel.elf 0 0 0 0
-  ```
-
   ![alt text](assets/fifo_monitoring_executable_not_running.png)
 
 - When the delays are 20, 40, 80, and 160, respectively:


### PR DESCRIPTION
Image was referencing FIFO occupancy when the executable is not running, but a command was shown with the executable running with delays 0, which is incorrect