### PR TITLE
Fixes for Training 4 for 2025.1

### DIFF
--- a/Training4/icicle-kit-reference-design/script_support/additional_configurations/smarthls/invert_and_threshold/Makefile.user
+++ b/Training4/icicle-kit-reference-design/script_support/additional_configurations/smarthls/invert_and_threshold/Makefile.user
@@ -17,8 +17,9 @@ LOCAL_CONFIG = -legup-config=config.tcl
 #-------------------------------------------------
 # Additional compilation settings
 #-------------------------------------------------
-# To include the bmp.h header
-USER_CXX_FLAG += -I./
+# -O3 to optimize software without accelerators. Default is -O1.
+# -I./ to include the bmp.h header.
+USER_CXX_FLAG += -O3 -I./
 
 #-------------------------------------------------
 # Runtime settings

--- a/Training4/icicle-kit-reference-design/script_support/additional_configurations/smarthls/invert_and_threshold/main_variations/main.non-blocking.cpp
+++ b/Training4/icicle-kit-reference-design/script_support/additional_configurations/smarthls/invert_and_threshold/main_variations/main.non-blocking.cpp
@@ -61,11 +61,13 @@ int main(int argc, char **argv) {
     bmp_pixel_t *OutBitMap1 = (bmp_pixel_t*)hls_malloc(HEIGHT * WIDTH * sizeof(bmp_pixel_t), HLS_ALLOC_NONCACHED);
     bmp_pixel_t *OutBitMap2 = (bmp_pixel_t*)hls_malloc(HEIGHT * WIDTH * sizeof(bmp_pixel_t), HLS_ALLOC_NONCACHED);
 
+    double t0 = timestamp();
+
     #ifdef HAS_ACCELERATOR
     void *invert_virt_addr = invert_setup();
     void *threshold_to_zero_virt_addr = threshold_to_zero_setup();
     #endif
-    double t0 = timestamp();
+
     for(int i = 0; i < HEIGHT/N_ROWS; i++) {
         if (do_invert) {
             #ifdef HAS_ACCELERATOR
@@ -91,6 +93,12 @@ int main(int argc, char **argv) {
             threshold_to_zero_join_and_read_output((uint32_t *)&OutBitMap2[i*WIDTH*N_ROWS], threshold_to_zero_virt_addr);
         #endif
     }
+
+    #ifdef HAS_ACCELERATOR
+    invert_teardown();
+    threshold_to_zero_teardown();
+    #endif
+
     double t1 = timestamp();
     printf("function elapsed time: %f [s]\n", t1 - t0);
 
@@ -99,10 +107,7 @@ int main(int argc, char **argv) {
     hls_free(OutBitMap1);
     hls_free(OutBitMap2);
     hls_free(BitMap);
-    #ifdef HAS_ACCELERATOR
-    invert_teardown();
-    threshold_to_zero_teardown();
-    #endif
+
     return 0;
 }
 

--- a/Training4/readme.md
+++ b/Training4/readme.md
@@ -81,7 +81,7 @@ Download the training design files in advance:
         4a1406ba9e764a94026fcea2ee8fbb84f91384e953e7ba6176fcb7dadcbc5522
   - Training design files for the [Running Vector-Add Reference SoC Generation on the Board](#running-vector-add-reference-soc-generation-on-the-board) section can be found on Github under [Training4/vector_add_soc](https://github.com/MicrochipTech/fpga-hls-examples/tree/main/Training4/vector_add_soc)
   - Training design files for the [Integrating SmartHLS into an Existing SoC design](#integrating-smarthls-into-an-existing-soc-design) section can be found on Github under [Training4/icicle-kit-reference-design](https://github.com/MicrochipTech/fpga-hls-examples/tree/main/Training4/icicle-kit-reference-design)
-  - Download `precompiled-binaries.tar.gz` from the Release Assets. This archive contains the pre-compiled bitstreams required for this training.
+  - Download `precompiled-binaries.tar.gz` from the [Release Assets](https://github.com/MicrochipTech/fpga-hls-examples/releases). This archive contains the pre-compiled bitstreams required for this training.
   - Alternatively, you can re-generate the bitstreams and Libero project from scratch by following the instructions
     here: [Compiling the hardware](#compiling-the-hardware).
 


### PR DESCRIPTION
Made the following changes:
- Included setup and teardown time in main.non-blocking.cpp
- Added -O3 in Makefile.user so that the default behaviour is similar to what is shown in Training 4 doc
- Updated the doc so that users will get the same results as the doc

Results from non-blocking with accelerators:
![image](https://github.com/user-attachments/assets/72138fe4-c723-47f6-85bd-21f9ea107fba)
which is around 72 ms as stated in the document.