### PR TITLE
risc-v-demo: Add warnings when PATH incorrect

### DIFF
--- a/risc-v-demo/sev-kit-reference-design/script_support/additional_configurations/smarthls/hls_pipeline/compile_and_copy.ps1
+++ b/risc-v-demo/sev-kit-reference-design/script_support/additional_configurations/smarthls/hls_pipeline/compile_and_copy.ps1
@@ -13,6 +13,16 @@ Set-StrictMode -Version Latest
 $SHLS_ROOT_DIR = Split-Path -Parent (Split-Path -Parent (Get-Command shls).Source)
 Write-Host  "SmartHLS root directory: $SHLS_ROOT_DIR"
 
+if (!(Get-Command riscv64-unknown-linux-gnu-g++ -ErrorAction SilentlyContinue)){
+	Write-Host "`nCaution: riscv64-unknown-linux-gnu-g++ not found, adding $SHLS_ROOT_DIR\swtools\binutils\riscv-gnu-toolchain\bin to PATH. Please check this!`n"
+	$env:PATH+=";$SHLS_ROOT_DIR\swtools\binutils\riscv-gnu-toolchain\bin"
+}
+
+if (!($Env:Path -split ";" -contains "$SHLS_ROOT_DIR\dependencies\lib\cygwin")){
+	Write-Host "`nCaution: Cygwin libs not found on PATH, adding $SHLS_ROOT_DIR\dependencies\lib\cygwin to PATH. Please check this!`n"
+	$env:PATH+=";$SHLS_ROOT_DIR\dependencies\lib\cygwin"
+}
+
 $EXAMPLE_ROOT_FOLDER = Join-Path -Path $PSScriptRoot -ChildPath './../../../../../'
 Write-Host "Example root folder: $EXAMPLE_ROOT_FOLDER"
 
@@ -97,7 +107,7 @@ if ($null -eq $env:BOARD_IP) {
 if ($arch -eq "riscv_64") {
     $copy_path = "root@" + $env:BOARD_IP + ":/srv/www/test/h264/"
     Write-Host "Copying file to board...(BOARD_IP:$copy_path)"
-    scp $ELF $copy_path
+    scp -O $ELF $copy_path
 
     Write-Host "Deleting output files"
     ssh "root@$env:BOARD_IP" "rm -f /srv/www/test/h264/output.*"

--- a/risc-v-demo/sev-kit-reference-design/script_support/additional_configurations/smarthls/hls_pipeline/compile_and_copy.sh
+++ b/risc-v-demo/sev-kit-reference-design/script_support/additional_configurations/smarthls/hls_pipeline/compile_and_copy.sh
@@ -8,6 +8,11 @@ set -e
 # Determine the location of SmartHLS
 SHLS_ROOT_DIR=$(dirname $(which shls))/..
 
+if [ ! $(which riscv64-unknown-linux-gnu-g++)]; then 
+        echo "Caution: riscv64-unknown-linux-gnu-g++ not found, adding $SHLS_ROOT_DIR/swtools/binutils/riscv-gnu-toolchain/bin to PATH. Please check this!"
+        export PATH=$PATH:$SHLS_ROOT_DIR/swtools/binutils/riscv-gnu-toolchain/bin
+fi
+
 EXAMPLE_ROOT_FOLDER=./../../../../../
 
 MODULE=hls_pipeline


### PR DESCRIPTION
 Prints caution note when riscv64-unknown-linux-gnu-g++ and the cygwin dlls aren't found on path, then guesses their locations and tries to add them to the path. 