### PR TITLE
Applying a Few Suggested Fixes to the Examples

### DIFF
--- a/Training1/Canny/bmp.hpp
+++ b/Training1/Canny/bmp.hpp
@@ -1,34 +1,7 @@
 #ifndef __PPM_H__
 #define __PPM_H__
 
-#include "hls/ap_int.hpp"
 #include "define.hpp"
-
-using namespace hls;
-
-// bit width of a pixel
-const int W = 8;
-
-// 24-bit RGB
-typedef ap_uint<3*W> rgb_t;
-
-// 7:0 blue
-const int B2 = 0;
-const int B1 = B2 + W-1;
-
-// 15:8 green
-const int G2 = W;
-const int G1 = G2 + W-1;
-
-// 23:16 red
-const int R2 = 2*W;
-const int R1 = R2 + W-1;
-
-struct input_t {
-    rgb_t      channel1;
-    rgb_t      channel2;
-    ap_uint<8> alpha;
-};
 
 #define SIZE (WIDTH*HEIGHT)
 

--- a/Training1/Canny/canny.cpp
+++ b/Training1/Canny/canny.cpp
@@ -11,9 +11,9 @@ void canny(hls::FIFO<unsigned char> &input_fifo,
 
 #ifndef __SYNTHESIS__
     // For software, the fifo depth has to be larger.
-    hls::FIFO<unsigned char> output_fifo_gf(WIDTH * HEIGHT * 2);
-    hls::FIFO<unsigned short> output_fifo_sf(WIDTH * HEIGHT * 2);
-    hls::FIFO<unsigned char> output_fifo_nm(WIDTH * HEIGHT * 2);
+    hls::FIFO<unsigned char> output_fifo_gf(WIDTH * HEIGHT);
+    hls::FIFO<unsigned short> output_fifo_sf(WIDTH * HEIGHT);
+    hls::FIFO<unsigned char> output_fifo_nm(WIDTH * HEIGHT);
 #else
     hls::FIFO<unsigned char> output_fifo_gf(/* depth = */ 2);
     hls::FIFO<unsigned short> output_fifo_sf(/* depth = */ 2);
@@ -28,8 +28,8 @@ void canny(hls::FIFO<unsigned char> &input_fifo,
 int main() {
     unsigned int i, j;
 
-    hls::FIFO<unsigned char> input_fifo(/* depth = */ WIDTH * HEIGHT * 2);
-    hls::FIFO<unsigned char> output_fifo(/* depth = */ WIDTH * HEIGHT * 2);
+    hls::FIFO<unsigned char> input_fifo(/* depth = */ WIDTH * HEIGHT);
+    hls::FIFO<unsigned char> output_fifo(/* depth = */ WIDTH * HEIGHT);
 
     bmp_header_t input_channel_header, golden_output_image_header;
     bmp_pixel_t *input_channel_sw, *input_channel, *golden_output_image,
@@ -92,11 +92,6 @@ int main() {
             input_fifo.write(grayscale);
             input_channel++;
         }
-    }
-
-    // Give more inputs to flush out all pixels.
-    for (i = 0; i < GF_KERNEL_SIZE * WIDTH + GF_KERNEL_SIZE; i++) {
-        input_fifo.write(0);
     }
 
     canny(input_fifo, output_fifo);

--- a/Training1/Canny/define.hpp
+++ b/Training1/Canny/define.hpp
@@ -20,8 +20,6 @@
 #endif
 #define SIZE (WIDTH*HEIGHT)
 
-void window_and_line_buffer(hls::ap_uint<10> input,
-                            hls::ap_uint<10> window[3][3]);
 
 // Gaussian Filter.
 const unsigned int GF_KERNEL_SIZE = 5;

--- a/Training1/Canny/nonmaximum_suppression.cpp
+++ b/Training1/Canny/nonmaximum_suppression.cpp
@@ -77,11 +77,17 @@ void nonmaximum_suppression(hls::FIFO<unsigned short> &input_fifo,
         // (suppress)
         int output = current_pixel;
 
+        #if defined(__GNUC__) && !defined(__clang__)
         #pragma GCC diagnostic push
         #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+        #endif
+
         output = (output >= avg1) ? output : 0;
         output = (output >= avg2) ? output : 0;
+
+        #if defined(__GNUC__) && !defined(__clang__)
         #pragma GCC diagnostic pop
+        #endif
 
         output_fifo.write(output);
     }

--- a/Training1/Canny_FIFO_Switch/bmp.hpp
+++ b/Training1/Canny_FIFO_Switch/bmp.hpp
@@ -1,34 +1,7 @@
 #ifndef __PPM_H__
 #define __PPM_H__
 
-#include "hls/ap_int.hpp"
 #include "define.hpp"
-
-using namespace hls;
-
-// bit width of a pixel
-const int W = 8;
-
-// 24-bit RGB
-typedef ap_uint<3*W> rgb_t;
-
-// 7:0 blue
-const int B2 = 0;
-const int B1 = B2 + W-1;
-
-// 15:8 green
-const int G2 = W;
-const int G1 = G2 + W-1;
-
-// 23:16 red
-const int R2 = 2*W;
-const int R1 = R2 + W-1;
-
-struct input_t {
-    rgb_t      channel1;
-    rgb_t      channel2;
-    ap_uint<8> alpha;
-};
 
 #define SIZE (WIDTH*HEIGHT)
 

--- a/Training1/Canny_FIFO_Switch/canny.cpp
+++ b/Training1/Canny_FIFO_Switch/canny.cpp
@@ -15,9 +15,9 @@ void canny(bool switch_0,
 
 #ifndef __SYNTHESIS__
     // For software, the fifo depth has to be larger.
-    hls::FIFO<unsigned char> output_fifo_gf(WIDTH * HEIGHT * 2);
-    hls::FIFO<unsigned short> output_fifo_sf(WIDTH * HEIGHT * 2);
-    hls::FIFO<unsigned char> output_fifo_nm(WIDTH * HEIGHT * 2);
+    hls::FIFO<unsigned char> output_fifo_gf(WIDTH * HEIGHT);
+    hls::FIFO<unsigned short> output_fifo_sf(WIDTH * HEIGHT);
+    hls::FIFO<unsigned char> output_fifo_nm(WIDTH * HEIGHT);
 #else
     hls::FIFO<unsigned char> output_fifo_gf(/* depth = */ 2);
     hls::FIFO<unsigned short> output_fifo_sf(/* depth = */ 2);
@@ -99,11 +99,6 @@ int main() {
             input_fifo.write(grayscale);
             input_channel++;
         }
-    }
-
-    // Give more inputs to flush out all pixels.
-    for (i = 0; i < GF_KERNEL_SIZE * WIDTH + GF_KERNEL_SIZE; i++) {
-        input_fifo.write(0);
     }
 
     switch_0 = true;

--- a/Training1/Canny_FIFO_Switch/define.hpp
+++ b/Training1/Canny_FIFO_Switch/define.hpp
@@ -20,8 +20,6 @@
 #endif
 #define SIZE (WIDTH*HEIGHT)
 
-void window_and_line_buffer(hls::ap_uint<10> input,
-                            hls::ap_uint<10> window[3][3]);
 
 // Gaussian Filter.
 const unsigned int GF_KERNEL_SIZE = 5;

--- a/Training1/Canny_FIFO_Switch/nonmaximum_suppression.cpp
+++ b/Training1/Canny_FIFO_Switch/nonmaximum_suppression.cpp
@@ -79,11 +79,17 @@ void nonmaximum_suppression(bool on_switch,
         // (suppress)
         int output = current_pixel;
 
+        #if defined(__GNUC__) && !defined(__clang__)
         #pragma GCC diagnostic push
         #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+        #endif
+
         output = (output >= avg1) ? output : 0;
         output = (output >= avg2) ? output : 0;
+
+        #if defined(__GNUC__) && !defined(__clang__)
         #pragma GCC diagnostic pop
+        #endif
 
         output_fifo.write(output);
     }

--- a/risc-v-demo/sev-kit-reference-design/script_support/additional_configurations/smarthls/hls_pipeline/config.tcl
+++ b/risc-v-demo/sev-kit-reference-design/script_support/additional_configurations/smarthls/hls_pipeline/config.tcl
@@ -1,6 +1,5 @@
 source $env(SHLS_ROOT_DIR)/examples/shls.tcl
 set_project PolarFireSoC MPFS250T Icicle_SoC
-set_parameter POINTSTO_ANALYZE_HW_ONLY 1
 
 # Prevent CPU usage of 100% while polling
 set_parameter SOC_POLL_DELAY 1

--- a/risc-v-demo/sev-kit-reference-design/script_support/additional_configurations/smarthls/rotozoom/config.tcl
+++ b/risc-v-demo/sev-kit-reference-design/script_support/additional_configurations/smarthls/rotozoom/config.tcl
@@ -1,6 +1,5 @@
 source $env(SHLS_ROOT_DIR)/examples/shls.tcl
 set_project PolarFireSoC MPFS250T Icicle_SoC
-set_parameter POINTSTO_ANALYZE_HW_ONLY 1
 
 #
 # Parameters used for SoC integration

--- a/sobel_tutorial/part2/sobel.cpp
+++ b/sobel_tutorial/part2/sobel.cpp
@@ -15,31 +15,37 @@ void sobel_filter(unsigned char in[HEIGHT][WIDTH],
     const static int gy[3][3] = {{1, 2, 1}, {0, 0, 0}, {-1, -2, -1}};
 
     int x = 0;
-    int y = 1;
+    int y = 0;
 #pragma HLS loop pipeline
-    for (int i = 0; i < (HEIGHT - 2) * (WIDTH - 2); i++) {
-        // increment row when column reaches end of row
-        y = (x == WIDTH - 2) ? y + 1 : y;
-        // increment column until end of row
-        x = (x == WIDTH - 2) ? 1 : x + 1;
+    for (int i = 0; i < HEIGHT * WIDTH; i++) {
+        // Output '0' when receptive field is not in bound
+        int sum = 0;
 
-        // Apply the sobel filter at the current "receptive field".
-        int gx_sum = 0, gy_sum = 0;
-        for (int m = -1; m <= 1; m++) {
-            for (int n = -1; n <= 1; n++) {
-                int pixel = in[y + m][x + n];
-                gx_sum += pixel * gx[m + 1][n + 1];
-                gy_sum += pixel * gy[m + 1][n + 1];
+        // if the receptive field is in bound
+        if ((x <  WIDTH - 1) && (x >= 1) && (y < HEIGHT - 1) && (y >= 1)) {
+            // Apply the sobel filter at the current "receptive field".
+            int gx_sum = 0, gy_sum = 0;
+            for (int m = -1; m <= 1; m++) {
+                for (int n = -1; n <= 1; n++) {
+                    int pixel = in[y + m][x + n];
+                    gx_sum += pixel * gx[m + 1][n + 1];
+                    gy_sum += pixel * gy[m + 1][n + 1];
+                }
             }
+
+            gx_sum = (gx_sum < 0) ? -gx_sum : gx_sum;
+            gy_sum = (gy_sum < 0) ? -gy_sum : gy_sum;
+
+            sum = gx_sum + gy_sum;
+            sum = (sum > 255) ? 255 : sum;
         }
 
-        gx_sum = (gx_sum < 0) ? -gx_sum : gx_sum;
-        gy_sum = (gy_sum < 0) ? -gy_sum : gy_sum;
-
-        int sum = gx_sum + gy_sum;
-        sum = (sum > 255) ? 255 : sum;
-
         out[y][x] = (unsigned char)sum;
+
+        // increment row when column reaches end of row
+        y = (x == WIDTH - 1) ? y + 1 : y;
+        // increment column until end of row
+        x = (x == WIDTH - 1) ? 0 : x + 1;
     }
 }
 
@@ -50,8 +56,8 @@ int main() {
 
     int mismatch_count = 0;
 
-    for (int i = 1; i < HEIGHT - 1; i++) {
-        for (int j = 1; j < WIDTH - 1; j++) {
+    for (int i = 0; i < HEIGHT; i++) {
+        for (int j = 0; j < WIDTH; j++) {
             if (sobel_output[i][j] != elaine_512_golden_output[i][j])
                 mismatch_count++;
         }

--- a/sobel_tutorial/part3/sobel.cpp
+++ b/sobel_tutorial/part3/sobel.cpp
@@ -71,8 +71,8 @@ void sobel_filter(FIFO<unsigned char> &input_fifo,
 }
 
 int main() {
-    FIFO<unsigned char> input_fifo(/* depth: */ WIDTH * HEIGHT * 2);
-    FIFO<unsigned char> output_fifo(/* depth: */ WIDTH * HEIGHT * 2);
+    FIFO<unsigned char> input_fifo(/* depth: */ WIDTH * HEIGHT);
+    FIFO<unsigned char> output_fifo(/* depth: */ WIDTH * HEIGHT);
 
     // Write input pixels and run the hardware model.
     for (int i = 0; i < HEIGHT; i++) {


### PR DESCRIPTION
This PR adds the following suggested fixes:
* Bug fixes for sobel part 2.
* Reducing FIFO depth for sobel part 3, Canny, and Canny_FIFO_Switch.
* Resolving the unknown warning group message for Canny and Canny_FIFO_Switch
* Performing some cleanups:
  * Removing unused code for Canny and Canny_FIFO_Switch
  * Removing obsolete tcl parameter: POINTSTO_ANALYZE_HW_ONLY