### PR TITLE
H264_Iframe_Encoder IP to H264_Encoder; Add Libero+Ubuntu 22.04 warning

### DIFF
--- a/Training1/readme.md
+++ b/Training1/readme.md
@@ -75,6 +75,8 @@ SmartHLS 2025.2. Depending on the version you use, the results generated
 from your Libero® SoC and SmartHLS could be slightly different from that
 presented in this document.
 
+**NOTE:** If you are using Libero 2026.1 on Ubuntu 22.04, there is a known issue that causes the Libero script in this example to fail with `cat: /etc/redhat-release: No such file or directory`. To workaround this issue, follow the instructions in this Knowledge Base article: [https://support.microchip.com/s/article/SmartHLS-v2026-1-Generate-Libero-Design-Fails-on-Ubuntu-22-04-3-LTS](https://support.microchip.com/s/article/SmartHLS-v2026-1-Generate-Libero-Design-Fails-on-Ubuntu-22-04-3-LTS). This issue will be fixed in the next release of Libero.
+
 You should download the training design files in advance:
 
   - Github link to all SmartHLS trainings and examples:

--- a/Training2/readme.md
+++ b/Training2/readme.md
@@ -124,6 +124,8 @@ SmartHLS 2025.2. Depending on the version you use, the results generated
 from your Libero® SoC and SmartHLS could be slightly different from that
 presented in this document.
 
+**NOTE:** If you are using Libero 2026.1 on Ubuntu 22.04, there is a known issue that causes the Libero script in this example to fail with `cat: /etc/redhat-release: No such file or directory`. To workaround this issue, follow the instructions in this Knowledge Base article: [https://support.microchip.com/s/article/SmartHLS-v2026-1-Generate-Libero-Design-Fails-on-Ubuntu-22-04-3-LTS](https://support.microchip.com/s/article/SmartHLS-v2026-1-Generate-Libero-Design-Fails-on-Ubuntu-22-04-3-LTS). This issue will be fixed in the next release of Libero.
+
 You should download the training design files in advance:
   - Github link to all SmartHLS trainings and examples:
     <https://github.com/MicrochipTech/fpga-hls-examples>

--- a/Training3/readme.md
+++ b/Training3/readme.md
@@ -124,6 +124,8 @@ SmartHLS 2025.2. Depending on the version you use, the results generated
 from your Libero® SoC and SmartHLS could be slightly different from that
 presented in this document.
 
+**NOTE:** If you are using Libero 2026.1 on Ubuntu 22.04, there is a known issue that causes the Libero script in this example to fail with `cat: /etc/redhat-release: No such file or directory`. To workaround this issue, follow the instructions in this Knowledge Base article: [https://support.microchip.com/s/article/SmartHLS-v2026-1-Generate-Libero-Design-Fails-on-Ubuntu-22-04-3-LTS](https://support.microchip.com/s/article/SmartHLS-v2026-1-Generate-Libero-Design-Fails-on-Ubuntu-22-04-3-LTS). This issue will be fixed in the next release of Libero.
+
 Additionally, while the default simulator for SmartHLS is now QuestaSim, ModelSim will still be supported. Some screenshots of the simulator may have been captured using Modelsim.
 
 You should download the training design files in advance:

--- a/Training4/readme.md
+++ b/Training4/readme.md
@@ -72,6 +72,8 @@ You should install the following software:
 
 This document uses the Windows versions of Libero® SoC 2025.2 and SmartHLS 2025.2. Depending on the version you use, the results generated from your Libero® SoC and SmartHLS could be slightly different from that presented in this document.
 
+**NOTE:** If you are using Libero 2026.1 on Ubuntu 22.04, there is a known issue that causes the Libero script in this example to fail with `cat: /etc/redhat-release: No such file or directory`. To workaround this issue, follow the instructions in this Knowledge Base article: [https://support.microchip.com/s/article/SmartHLS-v2026-1-Generate-Libero-Design-Fails-on-Ubuntu-22-04-3-LTS](https://support.microchip.com/s/article/SmartHLS-v2026-1-Generate-Libero-Design-Fails-on-Ubuntu-22-04-3-LTS). This issue will be fixed in the next release of Libero.
+
 Additionally, while the default simulator for SmartHLS is now QuestaSim, ModelSim will still be supported. Some screenshots of the simulator may have been captured using Modelsim.
 
 ## Download Training Design Files

--- a/auto_instrument/README.md
+++ b/auto_instrument/README.md
@@ -45,6 +45,8 @@ Before beginning this tutorial, you should install the following software:
 
 - Libero® SoC 2025.2 or later ([Download Page](https://www.microchip.com/en-us/products/fpgas-and-plds/fpga-and-soc-design-tools/fpga/libero-software-later-versions)). SmartHLS™ is packaged with Libero
 
+**NOTE:** If you are using Libero 2026.1 on Ubuntu 22.04, there is a known issue that causes the Libero script in this example to fail with `cat: /etc/redhat-release: No such file or directory`. To workaround this issue, follow the instructions in this Knowledge Base article: [https://support.microchip.com/s/article/SmartHLS-v2026-1-Generate-Libero-Design-Fails-on-Ubuntu-22-04-3-LTS](https://support.microchip.com/s/article/SmartHLS-v2026-1-Generate-Libero-Design-Fails-on-Ubuntu-22-04-3-LTS). This issue will be fixed in the next release of Libero.
+
 - The following hardware is required:
   - PolarFire® SoC FPGA Icicle Kit. Please follow [this link](https://onlinedocs.microchip.com/oxy/GUID-AFCB5DCC-964F-4BE7-AA46-C756FA87ED7B-en-US-13/GUID-1F9BA312-87A9-43F0-A66E-B83D805E3F02.html) to set up your Icicle Kit and make sure Linux boots-up and that the board has an IP network address assigned to it.
   - This example can be used in a local or remote configuration depending on where the Icicle Kit board is connected to via JTAG. The *JTAG host* is the machine that is connected to the board and the *build host* is the machine where the project is compiled. See the following diagram:

--- a/risc-v-demo/sev-kit-reference-design/MPFS_SEV_KIT_REFERENCE_DESIGN.tcl
+++ b/risc-v-demo/sev-kit-reference-design/MPFS_SEV_KIT_REFERENCE_DESIGN.tcl
@@ -114,7 +114,7 @@ if { [file exists $project_dir/$project_name.prjx] } {
     set RGBtoYCbCr_version              4.4.0
     set PF_XCVR_REF_CLK_version         1.0.103
     set DDR_AXI4_ARBITER_PF_version     2.1.0
-    set H264_Iframe_Encoder_version     1.3.0 
+    set H264_Encoder_version            2.0.0
     # The interconnect is needed in HLS integration scripts, which still use the "*" convention
     set COREAXI4INTERCONNECT_version    *
 
@@ -135,7 +135,7 @@ if { [file exists $project_dir/$project_name.prjx] } {
     download_core -vlnv Microsemi:SolutionCore:RGBtoYCbCr:$RGBtoYCbCr_version -location {www.microchip-ip.com/repositories/DirectCore}
     download_core -vlnv Actel:SgCore:PF_XCVR_REF_CLK:$PF_XCVR_REF_CLK_version -location {www.microchip-ip.com/repositories/SgCore}
     download_core -vlnv Microsemi:SolutionCore:DDR_AXI4_ARBITER_PF:$DDR_AXI4_ARBITER_PF_version -location {www.microchip-ip.com/repositories/DirectCore}
-    download_core -vlnv Microchip:SolutionCore:H264_Iframe_Encoder:$H264_Iframe_Encoder_version -location {www.microchip-ip.com/repositories/DirectCore}
+	download_core -vlnv Microchip:SolutionCore:H264_Encoder:$H264_Encoder_version -location {www.microchip-ip.com/repositories/DirectCore}
     download_core -vlnv Actel:DirectCore:COREAXI4INTERCONNECT:$COREAXI4INTERCONNECT_version -location {www.microchip-ip.com/repositories/DirectCore}
 
     #
@@ -186,7 +186,7 @@ if { [file exists $project_dir/$project_name.prjx] } {
     source ${src_path}/components/H264/FIC_CONVERTER.tcl
     source ${src_path}/components/CAM_IOD_TIP_TOP.tcl
     source ${src_path}/components/IMX334_IF_TOP.tcl
-    source ${src_path}/components/H264/H264_Iframe_Encoder_C0.tcl
+    source ${src_path}/components/H264/H264_Encoder_C0.tcl
     source ${src_path}/components/H264/H264_DDR_WRITE.tcl
     source ${src_path}/components/H264/h264_top.tcl
     source ${src_path}/components/video_processing.tcl

--- a/risc-v-demo/sev-kit-reference-design/script_support/components/H264/H264_DDR_WRITE.tcl
+++ b/risc-v-demo/sev-kit-reference-design/script_support/components/H264/H264_DDR_WRITE.tcl
@@ -1,3 +1,4 @@
+puts "TCL_BEGIN: [info script]"
 # Creating SmartDesign H264_DDR_WRITE
 set sd_name {H264_DDR_WRITE}
 create_smartdesign -sd_name ${sd_name}
@@ -22,7 +23,7 @@ sd_create_scalar_port -sd_name ${sd_name} -port_name {write_req_o} -port_directi
 
 
 # Create top level Bus Ports
-sd_create_bus_port -sd_name ${sd_name} -port_name {data_i} -port_direction {IN} -port_range {[7:0]}
+sd_create_bus_port -sd_name ${sd_name} -port_name {data_i} -port_direction {IN} -port_range {[15:0]}
 sd_create_bus_port -sd_name ${sd_name} -port_name {frame_ddr_addr_i} -port_direction {IN} -port_range {[9:0]}
 
 sd_create_bus_port -sd_name ${sd_name} -port_name {frame_bytes_o} -port_direction {OUT} -port_range {[31:0]}
@@ -41,7 +42,7 @@ sd_instantiate_macro -sd_name ${sd_name} -macro_name {AND2} -instance_name {AND2
 sd_instantiate_hdl_core -sd_name ${sd_name} -hdl_core_name {data_packer_h264} -instance_name {data_packer_h264_0}
 # Exporting Parameters of instance data_packer_h264_0
 sd_configure_core_instance -sd_name ${sd_name} -instance_name {data_packer_h264_0} -params {\
-"g_IP_DW:8" \
+"g_IP_DW:16" \
 "g_OP_DW:64" }\
 -validate_rules 0
 sd_save_core_instance_config -sd_name ${sd_name} -instance_name {data_packer_h264_0}
@@ -105,3 +106,4 @@ auto_promote_pad_pins -promote_all 1
 save_smartdesign -sd_name ${sd_name}
 # Generate SmartDesign H264_DDR_WRITE
 generate_component -component_name ${sd_name}
+puts "TCL_END: [info script]"

--- a/risc-v-demo/sev-kit-reference-design/script_support/components/H264/H264_Encoder_C0.tcl
+++ b/risc-v-demo/sev-kit-reference-design/script_support/components/H264/H264_Encoder_C0.tcl
@@ -1,0 +1,19 @@
+# Exporting Component Description of H264_Encoder_C0 to TCL
+# Family: PolarFireSoC
+# Part Number: MPFS250TS-1FCG1152I
+# Create and Configure the core component H264_Encoder_C0
+create_and_configure_core -core_vlnv Microchip:SolutionCore:H264_Encoder:$H264_Encoder_version -component_name {H264_Encoder_C0} -params {\
+"G_4K_EN:0"  \
+"G_16x16_INTRA_PRED:1"  \
+"G_AXI4L:0"  \
+"G_DDR_AXI_DW:512"  \
+"G_FRM_GAP:1"  \
+"G_HRES:1920"  \
+"G_LINE_GAP:8192"  \
+"G_P_CNT:16"  \
+"G_P_FRM:0"  \
+"G_QFACTOR:30"  \
+"G_SKIP_TH:512"  \
+"G_SLICES:1"  \
+"G_VRES:1072"   }
+# Exporting Component Description of H264_Encoder_C0 to TCL done

--- a/risc-v-demo/sev-kit-reference-design/script_support/components/H264/H264_Iframe_Encoder_C0.tcl
+++ b/risc-v-demo/sev-kit-reference-design/script_support/components/H264/H264_Iframe_Encoder_C0.tcl
@@ -1,8 +1,0 @@
-# Exporting Component Description of H264_Iframe_Encoder_C0 to TCL
-# Family: PolarFireSoC
-# Part Number: MPFS250T-1FCG1152
-# Create and Configure the core component H264_Iframe_Encoder_C0
-create_and_configure_core -core_vlnv Microchip:SolutionCore:H264_Iframe_Encoder:$H264_Iframe_Encoder_version -component_name {H264_Iframe_Encoder_C0} -params {\
-"G_C_TYPE:1"  \
-"G_DW:8"   }
-# Exporting Component Description of H264_Iframe_Encoder_C0 to TCL done

--- a/risc-v-demo/sev-kit-reference-design/script_support/components/H264/SEVPFSOC_H264.tcl
+++ b/risc-v-demo/sev-kit-reference-design/script_support/components/H264/SEVPFSOC_H264.tcl
@@ -1,3 +1,4 @@
+puts "TCL_BEGIN: [info script]"
 # Creating SmartDesign SEVPFSOC_TOP
 set sd_name {SEVPFSOC_TOP}
 create_smartdesign -sd_name ${sd_name}
@@ -264,3 +265,4 @@ auto_promote_pad_pins -promote_all 1
 save_smartdesign -sd_name ${sd_name}
 # Generate SmartDesign SEVPFSOC_TOP
 generate_component -component_name ${sd_name}
+puts "TCL_END: [info script]"

--- a/risc-v-demo/sev-kit-reference-design/script_support/components/H264/Video_Pipeline.tcl
+++ b/risc-v-demo/sev-kit-reference-design/script_support/components/H264/Video_Pipeline.tcl
@@ -1,3 +1,4 @@
+puts "TCL_BEGIN: [info script]"
 # Creating SmartDesign Video_Pipeline
 set sd_name {Video_Pipeline}
 create_smartdesign -sd_name ${sd_name}
@@ -162,6 +163,7 @@ sd_instantiate_component -sd_name ${sd_name} -component_name {RGBtoYCbCr_C0} -in
 
 # Add video_processing_0 instance
 sd_instantiate_component -sd_name ${sd_name} -component_name {video_processing} -instance_name {video_processing_0}
+sd_mark_pins_unused -sd_name ${sd_name} -pin_names {video_processing_0:eof_encoder_o}
 
 
 
@@ -219,3 +221,4 @@ auto_promote_pad_pins -promote_all 1
 save_smartdesign -sd_name ${sd_name}
 # Generate SmartDesign Video_Pipeline
 generate_component -component_name ${sd_name}
+puts "TCL_BEGIN: [info script]"

--- a/risc-v-demo/sev-kit-reference-design/script_support/components/H264/h264_top.tcl
+++ b/risc-v-demo/sev-kit-reference-design/script_support/components/H264/h264_top.tcl
@@ -146,7 +146,7 @@ sd_connect_pins -sd_name ${sd_name} -pin_names {"DDR_AXI4_ARBITER_PF_C0_0:w0_don
 sd_connect_pins -sd_name ${sd_name} -pin_names {"DDR_AXI4_ARBITER_PF_C0_0:w0_req_i" "H264_DDR_WRITE_64:write_req_o" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:clr_intr_i" "clr_intr_i" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:data_valid_i" "H264_Encoder_C0_0:DATA0_VALID_O" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:frame_end_i" "H264_Encoder_C0_0:FRAME_START_O" "eof_i"}
+sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:frame_end_i" "H264_Encoder_C0_0:FRAME_START_O" "eof_i" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:frm_interrupt_o" "frm_interrupt_o" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:h264_clk_i" "H264_Encoder_C0_0:PIX_CLK_I" "sys_clk_i" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Encoder_C0_0:DATA_VALID_I" "data_valid_i" }

--- a/risc-v-demo/sev-kit-reference-design/script_support/components/H264/h264_top.tcl
+++ b/risc-v-demo/sev-kit-reference-design/script_support/components/H264/h264_top.tcl
@@ -1,3 +1,4 @@
+puts "TCL_BEGIN: [info script]"
 # Creating SmartDesign h264_top
 set sd_name {h264_top}
 create_smartdesign -sd_name ${sd_name}
@@ -11,8 +12,8 @@ sd_create_scalar_port -sd_name ${sd_name} -port_name {awready} -port_direction {
 sd_create_scalar_port -sd_name ${sd_name} -port_name {bvalid} -port_direction {IN}
 sd_create_scalar_port -sd_name ${sd_name} -port_name {clr_intr_i} -port_direction {IN}
 sd_create_scalar_port -sd_name ${sd_name} -port_name {data_valid_i} -port_direction {IN}
-sd_create_scalar_port -sd_name ${sd_name} -port_name {ddr_ctrl_ready_i} -port_direction {IN}
 sd_create_scalar_port -sd_name ${sd_name} -port_name {eof_i} -port_direction {IN}
+sd_create_scalar_port -sd_name ${sd_name} -port_name {ddr_ctrl_ready_i} -port_direction {IN}
 sd_create_scalar_port -sd_name ${sd_name} -port_name {fic_clk} -port_direction {IN}
 sd_create_scalar_port -sd_name ${sd_name} -port_name {frame_valid_i} -port_direction {IN}
 sd_create_scalar_port -sd_name ${sd_name} -port_name {h264_encoder_en} -port_direction {IN}
@@ -128,14 +129,14 @@ sd_instantiate_component -sd_name ${sd_name} -component_name {H264_DDR_WRITE} -i
 
 
 # Add H264_Iframe_Encoder_C0_0 instance
-sd_instantiate_component -sd_name ${sd_name} -component_name {H264_Iframe_Encoder_C0} -instance_name {H264_Iframe_Encoder_C0_0}
-
+sd_instantiate_component -sd_name ${sd_name} -component_name {H264_Encoder_C0} -instance_name {H264_Encoder_C0_0}
+sd_connect_pins_to_constant -sd_name ${sd_name} -pin_names {H264_Encoder_C0_0:ENABLE_I} -value {VCC}
 
 
 # Add scalar net connections
 sd_connect_pins -sd_name ${sd_name} -pin_names {"AND2_0:A" "resetn_i" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"AND2_0:B" "H264_DDR_WRITE_64:h264_encoder_en_i" "h264_encoder_en" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"AND2_0:Y" "H264_Iframe_Encoder_C0_0:RESET_N" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"AND2_0:Y" "H264_Encoder_C0_0:RESET_N" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"DDR_AXI4_ARBITER_PF_C0_0:ddr_ctrl_ready_i" "ddr_ctrl_ready_i" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"DDR_AXI4_ARBITER_PF_C0_0:reset_i" "H264_DDR_WRITE_64:reset_i" "read_reset_i" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"DDR_AXI4_ARBITER_PF_C0_0:sys_clk_i" "H264_DDR_WRITE_64:ddr_clk_i" "fic_clk" }
@@ -144,26 +145,26 @@ sd_connect_pins -sd_name ${sd_name} -pin_names {"DDR_AXI4_ARBITER_PF_C0_0:w0_dat
 sd_connect_pins -sd_name ${sd_name} -pin_names {"DDR_AXI4_ARBITER_PF_C0_0:w0_done_o" "H264_DDR_WRITE_64:write_done_i" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"DDR_AXI4_ARBITER_PF_C0_0:w0_req_i" "H264_DDR_WRITE_64:write_req_o" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:clr_intr_i" "clr_intr_i" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:data_valid_i" "H264_Iframe_Encoder_C0_0:DATA_VALID_O" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:frame_end_i" "H264_Iframe_Encoder_C0_0:FRAME_END_I" "eof_i" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:data_valid_i" "H264_Encoder_C0_0:DATA0_VALID_O" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:frame_end_i" "H264_Encoder_C0_0:FRAME_START_O" "eof_i"}
 sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:frm_interrupt_o" "frm_interrupt_o" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:h264_clk_i" "H264_Iframe_Encoder_C0_0:PIX_CLK" "sys_clk_i" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Iframe_Encoder_C0_0:DATA_VALID_I" "data_valid_i" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Iframe_Encoder_C0_0:FRAME_START_I" "frame_valid_i" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:h264_clk_i" "H264_Encoder_C0_0:PIX_CLK_I" "sys_clk_i" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Encoder_C0_0:DATA_VALID_I" "data_valid_i" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Encoder_C0_0:FRAME_START_I" "frame_valid_i" }
 
 # Add bus net connections
 sd_connect_pins -sd_name ${sd_name} -pin_names {"DDR_AXI4_ARBITER_PF_C0_0:w0_burst_size_i" "H264_DDR_WRITE_64:write_length_o" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"DDR_AXI4_ARBITER_PF_C0_0:w0_data_i" "H264_DDR_WRITE_64:rdata_o" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"DDR_AXI4_ARBITER_PF_C0_0:w0_wstart_addr_i" "H264_DDR_WRITE_64:write_start_addr_o" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:data_i" "H264_Iframe_Encoder_C0_0:DATA_O" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:data_i" "H264_Encoder_C0_0:DATA0_O" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:frame_bytes_o" "frame_bytes_o" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:frame_ddr_addr_i" "frame_ddr_addr_i" }
 sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_DDR_WRITE_64:frame_index_o" "frame_index_o" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Iframe_Encoder_C0_0:DATA_C_I" "data_c_i" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Iframe_Encoder_C0_0:DATA_Y_I" "data_y_i" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Iframe_Encoder_C0_0:HRES_I" "hres_i" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Iframe_Encoder_C0_0:QP_I" "qp_i" }
-sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Iframe_Encoder_C0_0:VRES_I" "vres_i" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Encoder_C0_0:DATA_C_I" "data_c_i" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Encoder_C0_0:DATA_Y_I" "data_y_i" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Encoder_C0_0:HRES_I" "hres_i" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Encoder_C0_0:QP_I" "qp_i" }
+sd_connect_pins -sd_name ${sd_name} -pin_names {"H264_Encoder_C0_0:VRES_I" "vres_i" }
 
 # Add bus interface net connections
 sd_connect_pins -sd_name ${sd_name} -pin_names {"BIF_1" "DDR_AXI4_ARBITER_PF_C0_0:MIRRORED_SLAVE_AXI4" }
@@ -174,3 +175,4 @@ auto_promote_pad_pins -promote_all 1
 save_smartdesign -sd_name ${sd_name}
 # Generate SmartDesign h264_top
 generate_component -component_name ${sd_name}
+puts "TCL_BEGIN: [info script]"

--- a/sobel_tutorial/trainingdoc.md
+++ b/sobel_tutorial/trainingdoc.md
@@ -32,6 +32,8 @@ SmartHLS 2025.1 Depending on the version you use, the results generated
 from your Libero® SoC and SmartHLS could be slightly different from that
 presented in this document.
 
+**NOTE:** If you are using Libero 2026.1 on Ubuntu 22.04, there is a known issue that causes the Libero script in this example to fail with `cat: /etc/redhat-release: No such file or directory`. To workaround this issue, follow the instructions in this Knowledge Base article: [https://support.microchip.com/s/article/SmartHLS-v2026-1-Generate-Libero-Design-Fails-on-Ubuntu-22-04-3-LTS](https://support.microchip.com/s/article/SmartHLS-v2026-1-Generate-Libero-Design-Fails-on-Ubuntu-22-04-3-LTS). This issue will be fixed in the next release of Libero.
+
 ![](.//media/image2.png) We will use this cursor symbol throughout this
 tutorial to indicate sections where you need to perform actions to
 follow along.


### PR DESCRIPTION
Change the deprecated H264_Iframe_Encoder IP to H264_Encoder.
Add warning to all readmes about running Libero on Ubuntu 22.04.